### PR TITLE
Fixes #24 - Debugger was not evaluating breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Debugger was not evaluating breakpoints because a configuration was missing [#24](https://github.com/policy-design-lab/pdl-frontend/issues/24)
+
 ## [0.1.0] - 2023-01-23
 
 ### Added

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,6 +6,7 @@ const commonConfig = require('./webpack.common');
 
 module.exports = merge(commonConfig, {
     mode: 'development',
+    devtool: 'eval-source-map',
 
     devServer: {
         hot: true,


### PR DESCRIPTION
Debugger was not evaluating breakpoints due to a missing configuration option

## Description
Added devtool option. There are several values for this entry so we may want to look at this in the future.

## How Has This Been Tested?
To test this, set a breakpoint in app.tsx and it should evaluate it.

Changelog is updated.