### PR TITLE
Re-add update to landing page map after reversing back to original design

### DIFF
--- a/src/components/LandingPageMap.tsx
+++ b/src/components/LandingPageMap.tsx
@@ -120,7 +120,9 @@ const MapChart = ({ setTooltipContent, title }) => {
                                     >
                                         <Box>
                                             <Typography sx={{ color: "#2F7164" }}>{stateCodes[cur.id]}</Typography>
-                                            <Typography sx={{ color: "#2F7164" }}>Total Benefit</Typography>
+                                            (title === "Supplemental Nutrition Assistance Program (SNAP)" ?{" "}
+                                            <Typography sx={{ color: "#2F7164" }}>Total Cost</Typography>:
+                                            <Typography sx={{ color: "#2F7164" }}>Total Benefit</Typography>)
                                             <Typography sx={{ color: "#3F3F3F" }}>
                                                 $
                                                 {Number(total / 1000000.0).toLocaleString(undefined, {

--- a/src/components/LandingPageMap.tsx
+++ b/src/components/LandingPageMap.tsx
@@ -120,9 +120,11 @@ const MapChart = ({ setTooltipContent, title }) => {
                                     >
                                         <Box>
                                             <Typography sx={{ color: "#2F7164" }}>{stateCodes[cur.id]}</Typography>
-                                            (title === "Supplemental Nutrition Assistance Program (SNAP)" ?{" "}
-                                            <Typography sx={{ color: "#2F7164" }}>Total Cost</Typography>:
-                                            <Typography sx={{ color: "#2F7164" }}>Total Benefit</Typography>)
+                                            {title === "Supplemental Nutrition Assistance Program (SNAP)" ? (
+                                                <Typography sx={{ color: "#2F7164" }}>Total Cost</Typography>
+                                            ) : (
+                                                <Typography sx={{ color: "#2F7164" }}>Total Benefit</Typography>
+                                            )}
                                             <Typography sx={{ color: "#3F3F3F" }}>
                                                 $
                                                 {Number(total / 1000000.0).toLocaleString(undefined, {

--- a/src/pages/SNAPPage.tsx
+++ b/src/pages/SNAPPage.tsx
@@ -108,6 +108,9 @@ export default function SNAPPage(): JSX.Element {
                         pb: 5
                     }}
                 >
+                    <Box sx={{ display: "flex", justifyContent: "center" }}>
+                        <CardMedia sx={{ maxWidth: 720, mt: 3 }} component="img" src={snap} />
+                    </Box>
                     <div id="landingPageMapContainer">
                         <LandingPageMap programTitle="Supplemental Nutrition Assistance Program (SNAP)" />
                     </div>

--- a/src/pages/SNAPPage.tsx
+++ b/src/pages/SNAPPage.tsx
@@ -108,9 +108,6 @@ export default function SNAPPage(): JSX.Element {
                         pb: 5
                     }}
                 >
-                    <Box sx={{ display: "flex", justifyContent: "center" }}>
-                        <CardMedia sx={{ maxWidth: 720, mt: 3 }} component="img" src={snap} />
-                    </Box>
                     <div id="landingPageMapContainer">
                         <LandingPageMap programTitle="Supplemental Nutrition Assistance Program (SNAP)" />
                     </div>


### PR DESCRIPTION
After the revising landing page map back PR, some changes that are on the SNAP PR have been overwritten. Thus reverse them back.