### PR TITLE
Issue141: Add $ back to the beginning of legend on landing page map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Add `$` sign to the beginning of legend bar on landing page [#141](https://github.com/policy-design-lab/pdl-frontend/issues/141)
+
 ## [0.5.1] - 2023-05-30
 
 ### Changed
@@ -95,6 +101,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Map data json [#12](https://github.com/policy-design-lab/pdl-frontend/issues/12)
 - Final landing page changes for initial milestone [#15](https://github.com/policy-design-lab/pdl-frontend/issues/15)
 
+[unreleased]: https://github.com/policy-design-lab/pdl-frontend/compare/0.5.1...HEAD
 [0.5.1]: https://github.com/policy-design-lab/pdl-frontend/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/policy-design-lab/pdl-frontend/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/policy-design-lab/pdl-frontend/compare/0.3.0...0.4.0

--- a/src/components/shared/DrawLegend.tsx
+++ b/src/components/shared/DrawLegend.tsx
@@ -112,7 +112,7 @@ export default function DrawLegend({
                         .text((d, i) => {
                             if (i === 0) {
                                 const res = ShortFormat(Math.round(cut_points[i]), i);
-                                return res.indexOf("-") < 0 ? `${res}` : `-$${res.substring(1)}`;
+                                return res.indexOf("-") < 0 ? `$${res}` : `-$${res.substring(1)}`;
                             }
                             return ShortFormat(Math.round(cut_points[i]), i);
                         });
@@ -133,7 +133,7 @@ export default function DrawLegend({
                         .text((d, i) => {
                             if (i === 0) {
                                 const res = ShortFormat(Math.round(cut_points[i]), i);
-                                return res.indexOf("-") < 0 ? `${res}` : `-$${res.substring(1)}`;
+                                return res.indexOf("-") < 0 ? `$${res}` : `-$${res.substring(1)}`;
                             }
                             return ShortFormat(Math.round(cut_points[i]), i);
                         });


### PR DESCRIPTION
Fixed #141 and add the 'unreleased' section back to the changelog.

1. This branch is a checkout from the main, but it shouldn't have any conflict with the dev after #140 is merged.

2. Running this branch locally and you should see a $ for all legend bars on landing page maps:
![Screenshot 2023-05-30 at 10 11 03 AM](https://github.com/policy-design-lab/pdl-frontend/assets/92752107/70af1906-ab15-4a6b-adad-d17ca538bccb)