### PR TITLE
Disable users' access to title 1 page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Disable users' access to the Title 1 page [#161](https://github.com/policy-design-lab/pdl-frontend/issues/161)
+
 ## [0.6.0] - 2023-07-18
 
 ### Added
@@ -111,6 +117,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Map data json [#12](https://github.com/policy-design-lab/pdl-frontend/issues/12)
 - Final landing page changes for initial milestone [#15](https://github.com/policy-design-lab/pdl-frontend/issues/15)
 
+[unreleased]: https://github.com/policy-design-lab/pdl-frontend/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/policy-design-lab/pdl-frontend/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/policy-design-lab/pdl-frontend/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/policy-design-lab/pdl-frontend/compare/0.4.0...0.5.0

--- a/src/components/LandingDisplay.tsx
+++ b/src/components/LandingDisplay.tsx
@@ -33,7 +33,8 @@ export default function LandingDisplay({ programTitle }: { programTitle: string 
             bodyText =
                 "Title I, Commodities cover price and income support for the farmers who raise widely-produced and traded non-perishable crops, like corn, soybeans, wheat, cotton and rice – as well as dairy and sugar. The title also includes agricultural disaster assistance. The map shows the total benefits paid to farmers from of the commodities programs by state from 2018-2022.";
 
-            route = "/title1";
+            //route = "/title1";
+            route = "/";
             buttonText = "Explore Maps of Commodities Programs";
             button = (
                 <Button
@@ -45,8 +46,9 @@ export default function LandingDisplay({ programTitle }: { programTitle: string 
                         borderRadius: 0
                     }}
                     disableElevation
-                    component={Link}
-                    to={route}
+                    // component={Link}
+                    // to={route}
+                    onClick={handleAlertOpen}
                 >
                     <Typography variant="subtitle1">
                         <strong>{buttonText}</strong>

--- a/src/components/LandingDisplay.tsx
+++ b/src/components/LandingDisplay.tsx
@@ -33,7 +33,7 @@ export default function LandingDisplay({ programTitle }: { programTitle: string 
             bodyText =
                 "Title I, Commodities cover price and income support for the farmers who raise widely-produced and traded non-perishable crops, like corn, soybeans, wheat, cotton and rice – as well as dairy and sugar. The title also includes agricultural disaster assistance. The map shows the total benefits paid to farmers from of the commodities programs by state from 2018-2022.";
 
-            //route = "/title1";
+            // route = "/title1";
             route = "/";
             buttonText = "Explore Maps of Commodities Programs";
             button = (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,7 +21,7 @@ export default function Main(): JSX.Element {
                 <Route path="/" element={<LandingPage />} />
                 <Route path="/eqip" element={<EQIPPage />} />
                 <Route path="/csp" element={<CSPPage />} />
-                <Route path="/title1" element={<TitleIPage />} />
+                {/* <Route path="/title1" element={<TitleIPage />} /> */}
                 <Route path="/snap" element={<SNAPPage />} />
             </Routes>
         </ScrollToTop>


### PR DESCRIPTION
Fix #161 

This PR will reverse the button on the landing page for the Title 1 page back to its original status. When a user clicks 'Explore Map of Commodities Programs', they will see the 'on-building' placeholder image instead of being directed to the title1 page.

I also commented out the route code in case someone accidentally uses the title1 URL.