### PR TITLE
task#168: update front-end after title 1 new api deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Landing page clean up for use API endpoint by removing redundant calls [#148](https://github.com/policy-design-lab/pdl-frontend/issues/148)
 - CSP page uses API endpoint instead of local json file [#149](https://github.com/policy-design-lab/pdl-frontend/issues/149)
 - SNAP page landing page uses API endpoint following the pattern in Landing Page [#166](https://github.com/policy-design-lab/pdl-frontend/issues/166)
+- Updated the year related labels on landing page and title 1 page to reflect changes of new title 1 API [#168](https://github.com/policy-design-lab/pdl-frontend/issues/168)
 
 ## [0.6.0] - 2023-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CSP page uses API endpoint instead of local json file [#149](https://github.com/policy-design-lab/pdl-frontend/issues/149)
 - SNAP page landing page uses API endpoint following the pattern in Landing Page [#166](https://github.com/policy-design-lab/pdl-frontend/issues/166)
 - Updated the year related labels on landing page and title 1 page to reflect changes of new title 1 API [#168](https://github.com/policy-design-lab/pdl-frontend/issues/168)
+- Updated the landing page map tab to include a label to explain that the top-line numbers are not finalized [#171](https://github.com/policy-design-lab/pdl-frontend/issues/171)
 
 ## [0.6.0] - 2023-07-18
 

--- a/src/components/LandingPageMap.tsx
+++ b/src/components/LandingPageMap.tsx
@@ -149,7 +149,8 @@ const MapChart = (props) => {
                     programData={allPrograms.filter((d) => d.State !== "Total").map((d) => d[searchKey])}
                     prepColor={[color1, color2, color3, color4, color5]}
                     emptyState={zeroPoints}
-                    initWidth={window.innerWidth > 1679 ? window.innerWidth * 0.75 : window.innerWidth * 0.8}
+                    initRatioLarge={0.75}
+                    initRatioSmall={0.8}
                 />
             </Box>
             <ComposableMap projection="geoAlbersUsa">

--- a/src/components/LandingPageMap.tsx
+++ b/src/components/LandingPageMap.tsx
@@ -59,7 +59,7 @@ const MapChart = (props) => {
                         Total Farm Bill Benefits from <strong>2018 - 2022</strong>
                     </Typography>
                     <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
-                        <i>2022 payments for title 1 has not been paid</i>
+                        <i>2022 payments for Title I have not yet been paid</i>
                     </Typography>
                 </Box>
             );
@@ -77,7 +77,7 @@ const MapChart = (props) => {
                         Total Commodities Programs (Title I) from <strong>2018 - 2021</strong>
                     </Typography>
                     <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
-                        <i>2022 payments for title 1 has not been paid</i>
+                        <i>2022 payments for Title I have not yet been paid</i>
                     </Typography>
                 </Box>
             );

--- a/src/components/LandingPageMap.tsx
+++ b/src/components/LandingPageMap.tsx
@@ -54,9 +54,14 @@ const MapChart = (props) => {
             color4 = "#1B9577";
             color5 = "#005A45";
             legendTitle = (
-                <Typography noWrap variant="h6">
-                    Total Farm Bill Benefits from <strong>2018 - 2022</strong>
-                </Typography>
+                <Box>
+                    <Typography noWrap variant="h6">
+                        Total Farm Bill Benefits from <strong>2018 - 2022</strong>
+                    </Typography>
+                    <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
+                        <i>2022 payments for title 1 has not been paid</i>
+                    </Typography>
+                </Box>
             );
             break;
         case "Title I: Commodities":
@@ -67,9 +72,14 @@ const MapChart = (props) => {
             color4 = "#D95F0E";
             color5 = "#993404";
             legendTitle = (
-                <Typography noWrap variant="h6">
-                    Total Commodities Programs (Title I) from <strong>2018 - 2022</strong>
-                </Typography>
+                <Box>
+                    <Typography noWrap variant="h6">
+                        Total Commodities Programs (Title I) from <strong>2018 - 2021</strong>
+                    </Typography>
+                    <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
+                        <i>2022 payments for title 1 has not been paid</i>
+                    </Typography>
+                </Box>
             );
             break;
         case "Title II: Conservation":
@@ -262,18 +272,27 @@ const MapChart = (props) => {
                                                                         record["Fiscal Year"]
                                                                     }
                                                                 >
-                                                                    {record["Fiscal Year"]}:{" "}
-                                                                    {Number(record.Amount / 1000000.0) >= 0
-                                                                        ? `$${Number(
-                                                                              Math.abs(record.Amount) / 1000000.0
-                                                                          ).toLocaleString(undefined, {
-                                                                              maximumFractionDigits: 2
-                                                                          })}M`
-                                                                        : `-$${Number(
-                                                                              Math.abs(record.Amount) / 1000000.0
-                                                                          ).toLocaleString(undefined, {
-                                                                              maximumFractionDigits: 2
-                                                                          })}M`}
+                                                                    {String(record["Fiscal Year"]) === "2022" &&
+                                                                    title.includes("Title I") ? (
+                                                                        <div>2022: Not Available</div>
+                                                                    ) : (
+                                                                        <div>
+                                                                            {record["Fiscal Year"]}:{" "}
+                                                                            {Number(record.Amount / 1000000.0) >= 0
+                                                                                ? `$${Number(
+                                                                                      Math.abs(record.Amount) /
+                                                                                          1000000.0
+                                                                                  ).toLocaleString(undefined, {
+                                                                                      maximumFractionDigits: 2
+                                                                                  })}M`
+                                                                                : `-$${Number(
+                                                                                      Math.abs(record.Amount) /
+                                                                                          1000000.0
+                                                                                  ).toLocaleString(undefined, {
+                                                                                      maximumFractionDigits: 2
+                                                                                  })}M`}
+                                                                        </div>
+                                                                    )}
                                                                 </div>
                                                             ))}
                                                         </Typography>

--- a/src/components/LandingPageMap.tsx
+++ b/src/components/LandingPageMap.tsx
@@ -74,7 +74,7 @@ const MapChart = (props) => {
             legendTitle = (
                 <Box>
                     <Typography noWrap variant="h6">
-                        Total Commodities Programs (Title I) from <strong>2018 - 2021</strong>
+                        Total Commodities Programs (Title I) from <strong>2018 - 2022</strong>
                     </Typography>
                     <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
                         <i>2022 payments for Title I have not yet been paid</i>

--- a/src/components/LandingPageMapTab.tsx
+++ b/src/components/LandingPageMapTab.tsx
@@ -141,7 +141,7 @@ export default function LandingPageMapTab({
                             </Typography>
                             <Typography variant="h6" className="allSmallCaps" sx={{ mt: 1 }}>
                                 <strong>Map visualization</strong>{" "}
-                                <b style={{ color: "lightgrey" }}>(Numbers are not final)</b>
+                                <b style={{ color: "lightgrey" }}>(Numbers have not yet been finalized)</b>
                             </Typography>
                         </Box>
                         <Divider sx={{ mx: 1 }} orientation="vertical" variant="middle" flexItem />

--- a/src/components/LandingPageMapTab.tsx
+++ b/src/components/LandingPageMapTab.tsx
@@ -136,11 +136,12 @@ export default function LandingPageMapTab({
                         className="tab"
                     >
                         <Box sx={{ mt: 1.5, pb: 0, mr: 8 }}>
-                            <Typography variant="h4" className="smallCaps">
+                            <Typography variant="h4" className="smallCaps" style={{ textAlign: "center" }}>
                                 <strong>Farm Bill Data</strong>
                             </Typography>
                             <Typography variant="h6" className="allSmallCaps" sx={{ mt: 1 }}>
-                                <strong>Map visualization</strong>
+                                <strong>Map visualization</strong>{" "}
+                                <b style={{ color: "lightgrey" }}>(Numbers are not final)</b>
                             </Typography>
                         </Box>
                         <Divider sx={{ mx: 1 }} orientation="vertical" variant="middle" flexItem />

--- a/src/components/shared/DrawLegend.tsx
+++ b/src/components/shared/DrawLegend.tsx
@@ -139,10 +139,18 @@ export default function DrawLegend({
                         });
                 }
                 if (emptyState.length !== 0) {
+                    const middleText = baseSVG
+                        .append("text")
+                        .attr("class", "legendTextSide")
+                        .attr("x", -1000)
+                        .attr("y", -1000)
+                        .text(`${emptyState.join(", ")}'s data is not available`);
+                    const middleBox = middleText.node().getBBox();
+                    middleText.remove();
                     baseSVG
                         .append("text")
                         .attr("class", "legendTextSide")
-                        .attr("x", (svgWidth + margin * 2) / 2 - margin * 2)
+                        .attr("x", (svgWidth + margin * 2) / 2 - middleBox.width / 2)
                         .attr("y", 80)
                         .text(`${emptyState.join(", ")}'s data is not available`);
                 }

--- a/src/components/shared/DrawLegend.tsx
+++ b/src/components/shared/DrawLegend.tsx
@@ -14,20 +14,26 @@ export default function DrawLegend({
     programData,
     prepColor,
     emptyState,
-    initWidth
+    initRatioLarge,
+    initRatioSmall
 }: {
     colorScale: d3.ScaleThreshold<number, string>;
     title: React.ReactElement;
     programData: number[];
     prepColor: string[];
     emptyState: string[];
-    initWidth: number;
+    initRatioLarge: number;
+    initRatioSmall: number;
 }): JSX.Element {
     const legendRn = React.useRef(null);
     const margin = 40;
     let cut_points: number[] = [];
-    const [width, setWidth] = React.useState(initWidth);
+    const [width, setWidth] = React.useState(
+        window.innerWidth >= 1679 ? window.innerWidth * initRatioLarge : window.innerWidth * initRatioSmall
+    );
     React.useEffect(() => {
+        if (window.innerWidth > 1679) setWidth(window.innerWidth * initRatioLarge);
+        else setWidth(window.innerWidth * initRatioSmall);
         drawLegend();
     });
     const drawLegend = () => {

--- a/src/components/title1/Title1Map.tsx
+++ b/src/components/title1/Title1Map.tsx
@@ -378,7 +378,8 @@ const Title1Map = ({
                     programData={quantizeArray}
                     prepColor={mapColor}
                     emptyState={zeroPoints}
-                    initWidth={window.innerWidth > 1679 ? window.innerWidth * 0.6 : window.innerWidth * 0.5}
+                    initRatioLarge={0.6}
+                    initRatioSmall={0.5}
                 />
             </Box>
             <MapChart

--- a/src/components/title1/Title1Map.tsx
+++ b/src/components/title1/Title1Map.tsx
@@ -410,7 +410,7 @@ const titleElement = ({ program, subprogram, year }): JSX.Element => {
                     Total <strong>{subprogram}</strong> Payments from <strong>{year}</strong>
                 </Typography>
                 <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
-                    <i>2022 payments for title 1 has not been paid</i>
+                    <i>2022 payments for Title I have not yet been paid</i>
                 </Typography>
             </Box>
         );
@@ -423,7 +423,7 @@ const titleElement = ({ program, subprogram, year }): JSX.Element => {
                     <strong>{program}</strong> Payments from <strong>{year}</strong>
                 </Typography>{" "}
                 <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
-                    <i>2022 payments for title 1 has not been paid</i>
+                    <i>2022 payments for Title I have not yet been paid</i>
                 </Typography>
             </Box>
         );
@@ -434,7 +434,7 @@ const titleElement = ({ program, subprogram, year }): JSX.Element => {
                 Total <strong>{program}</strong> Payments from <strong>{year}</strong>
             </Typography>{" "}
             <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
-                <i>2022 payments for title 1 has not been paid</i>
+                <i>2022 payments for Title I have not yet been paid</i>
             </Typography>
         </Box>
     );

--- a/src/components/title1/Title1Map.tsx
+++ b/src/components/title1/Title1Map.tsx
@@ -404,22 +404,39 @@ const Title1Map = ({
 const titleElement = ({ program, subprogram, year }): JSX.Element => {
     if (subprogram) {
         return (
-            <Typography noWrap variant="h6">
-                Total <strong>{subprogram}</strong> Payments from <strong>{year}</strong>
-            </Typography>
+            <Box>
+                {" "}
+                <Typography noWrap variant="h6">
+                    Total <strong>{subprogram}</strong> Payments from <strong>{year}</strong>
+                </Typography>
+                <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
+                    <i>2022 payments for title 1 has not been paid</i>
+                </Typography>
+            </Box>
         );
     }
     if (program === "Total Commodities Programs") {
         return (
-            <Typography noWrap variant="h6">
-                <strong>{program}</strong> Payments from <strong>{year}</strong>
-            </Typography>
+            <Box>
+                {" "}
+                <Typography noWrap variant="h6">
+                    <strong>{program}</strong> Payments from <strong>{year}</strong>
+                </Typography>{" "}
+                <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
+                    <i>2022 payments for title 1 has not been paid</i>
+                </Typography>
+            </Box>
         );
     }
     return (
-        <Typography noWrap variant="h6">
-            Total <strong>{program}</strong> Payments from <strong>{year}</strong>
-        </Typography>
+        <Box>
+            <Typography noWrap variant="h6">
+                Total <strong>{program}</strong> Payments from <strong>{year}</strong>
+            </Typography>{" "}
+            <Typography noWrap style={{ fontSize: "0.5em", color: "#585858", textAlign: "center" }}>
+                <i>2022 payments for title 1 has not been paid</i>
+            </Typography>
+        </Box>
     );
 };
 export default Title1Map;

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -346,8 +346,7 @@ function Title1ProgramTable({
                                     }}
                                 >
                                     <i>
-                                        The payments are calculated as the total of the data from 2014-2021; The base
-                                        acres calculated as the average of the data from 2014-2022.
+                                    The payments,base acres and payment recipients are calculated as the total of the data from 2014-2021. 2022 payments for Title I have not yet been paid.
                                     </i>
                                 </Typography>
                             ) : (

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -289,9 +289,13 @@ function Title1ProgramTable({
             }
         }
 
-        @media screen and (max-width: 1680px) {
+        @media screen and (max-width: 1790px) {
             table {
                 font-size: 0.9em;
+            }
+            table th,
+            table td {
+                padding: 1em;
             }
             td[class$="cell${paymentsIndex}"],
             td[class$="cell${averageAreaInAcresIndex}"],
@@ -342,9 +346,8 @@ function Title1ProgramTable({
                                     }}
                                 >
                                     <i>
-                                        The payments are calculated as the total of the data from 2018-2022; The base
-                                        acres and payment recipients are calculated as the average of the data from
-                                        2019-2022.
+                                        The payments are calculated as the total of the data from 2014-2021; The base
+                                        acres calculated as the average of the data from 2014-2022.
                                     </i>
                                 </Typography>
                             ) : (

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -10,6 +10,7 @@ import {
     sortByDollars
 } from "../shared/TableCompareFunctions";
 import "../../styles/table.css";
+import { ToDollarString } from "../shared/ConvertionFormats";
 
 function Title1ProgramTable({
     tableTitle,
@@ -62,9 +63,12 @@ function Title1ProgramTable({
                 return value.paymentInPercentageNationwide !== undefined
                     ? {
                           state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                          paymentInDollars: `$${value.paymentInDollars
-                              .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                              .toString()}`,
+                          paymentInDollars: `$${
+                              value.paymentInDollars
+                                  .toLocaleString(undefined, { minimumFractionDigits: 0 })
+                                  .toString()
+                                  .split(".")[0]
+                          }`,
                           paymentInPercentageNationwide: `${value.paymentInPercentageNationwide.toString()}%`,
                           paymentInPercentageWithinState: `${value.paymentInPercentageWithinState.toString()}%`,
                           averageAreaInAcres:
@@ -92,18 +96,24 @@ function Title1ProgramTable({
             if (program === "Total Commodities Programs") {
                 return {
                     state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                    programPaymentInDollars: `$${value.programPaymentInDollars
-                        .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                        .toString()}`,
+                    programPaymentInDollars: `$${
+                        value.programPaymentInDollars
+                            .toLocaleString(undefined, { minimumFractionDigits: 2 })
+                            .toString()
+                            .split(".")[0]
+                    }`,
                     paymentInPercentageNationwide: `${value.paymentInPercentageNationwide.toString()}%`
                 };
             }
             return value.programPaymentInDollars !== undefined
                 ? {
                       state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                      programPaymentInDollars: `$${value.programPaymentInDollars
-                          .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                          .toString()}`,
+                      programPaymentInDollars: `$${
+                          value.programPaymentInDollars
+                              .toLocaleString(undefined, { minimumFractionDigits: 2 })
+                              .toString()
+                              .split(".")[0]
+                      }`,
                       averageAreaInAcres:
                           value.averageAreaInAcres === 0
                               ? "0"

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -346,7 +346,8 @@ function Title1ProgramTable({
                                     }}
                                 >
                                     <i>
-                                    The payments,base acres and payment recipients are calculated as the total of the data from 2014-2021. 2022 payments for Title I have not yet been paid.
+                                        The payments,base acres and payment recipients are calculated as the total of
+                                        the data from 2014-2021. 2022 payments for Title I have not yet been paid.
                                     </i>
                                 </Typography>
                             ) : (

--- a/src/components/title1/Title1TreeMap.tsx
+++ b/src/components/title1/Title1TreeMap.tsx
@@ -405,6 +405,7 @@ export default function Title1TreeMap({ program, TreeMapData, year, stateCodes, 
                         chartData={chartData}
                         color={{ baseAcres: baseAcresColor, payments: paymentsColor, recipients: recipientsColor }}
                         availableAttributes={availableAttributes}
+                        program={program}
                     />
                 </Grid>
             </Grid>

--- a/src/components/title1/Title1TreeMap.tsx
+++ b/src/components/title1/Title1TreeMap.tsx
@@ -213,8 +213,8 @@ export default function Title1TreeMap({ program, TreeMapData, year, stateCodes, 
                             }}
                         >
                             <i>
-                                The payments are calculated as the total of the data from 2018-2022; The base acres and
-                                payment recipients are calculated as the average of the data from 2019-2022.
+                                The payments are calculated as the total of the data from 2014-2021 (2022 payment is not available); The base acres and
+                                payment recipients are calculated as the average of the data from 2014-2022.
                             </i>
                         </Typography>
                         <Typography

--- a/src/components/title1/Title1TreeMap.tsx
+++ b/src/components/title1/Title1TreeMap.tsx
@@ -213,8 +213,7 @@ export default function Title1TreeMap({ program, TreeMapData, year, stateCodes, 
                             }}
                         >
                             <i>
-                                The payments are calculated as the total of the data from 2014-2021 (2022 payment is not available); The base acres and
-                                payment recipients are calculated as the average of the data from 2014-2022.
+                                The payments,base acres and payment recipients are calculated as the total of the data from 2014-2021. 2022 payments for Title I have not yet been paid.
                             </i>
                         </Typography>
                         <Typography

--- a/src/components/title1/TreeMapSquares.tsx
+++ b/src/components/title1/TreeMapSquares.tsx
@@ -82,7 +82,11 @@ export default function TreeMapSquares({
                                         const inSquareText = squareGroup
                                             .append("text")
                                             .attr("id", `inSquareText${value}`)
-                                            .text(collectedOriginalData[key])
+                                            .text(
+                                                key === "payments"
+                                                    ? `$${collectedOriginalData[key]}`
+                                                    : collectedOriginalData[key]
+                                            )
                                             .style("font-size", "0.7em")
                                             .style("fill", "white");
                                         const textLength = inSquareText.node().getComputedTextLength();

--- a/src/components/title1/TreeMapSquares.tsx
+++ b/src/components/title1/TreeMapSquares.tsx
@@ -10,7 +10,8 @@ export default function TreeMapSquares({
     originalData,
     chartData,
     color,
-    availableAttributes
+    availableAttributes,
+    program
 }): JSX.Element {
     const Styles = styled.div`
         #Title1TreeMap {
@@ -25,6 +26,8 @@ export default function TreeMapSquares({
             const base = d3.select(rn.current).append("g").attr("class", "base");
             const margin = 30;
             const lineMargin = 80;
+            const baseSize = 10;
+            const stepSize = 20;
             let rowTrack = 0;
             let largestSquare = 200;
             if (window.innerWidth >= 1920) {
@@ -109,12 +112,14 @@ export default function TreeMapSquares({
                             const mousePos = d3.pointer(event, squareGroup.node());
                             const tipGroup = base.append("g").attr("class", "TreeMapSquareTip");
                             const xPosition = mousePos[0] + 160 > svgWidth ? mousePos[0] - 160 : mousePos[0];
+                            const tipHeight =
+                                program === "Agriculture Risk Coverage Individual Coverage (ARC-IC)" ? 80 : 100;
                             tipGroup
                                 .append("rect")
                                 .attr("x", xPosition)
                                 .attr("y", mousePos[1])
                                 .attr("width", 155)
-                                .attr("height", 100)
+                                .attr("height", tipHeight)
                                 .attr("rx", 5)
                                 .attr("ry", 5)
                                 .attr("fill", "#2F7164")
@@ -131,32 +136,42 @@ export default function TreeMapSquares({
                                         ]
                                     }`
                                 )
-                                .attr("x", xPosition + 10)
-                                .attr("y", mousePos[1] + 20)
+                                .attr("x", xPosition + baseSize)
+                                .attr("y", mousePos[1] + stepSize * 1)
                                 .style("font-size", "0.9em")
                                 .style("font-weight", "700")
                                 .style("fill", "white");
                             tipGroup
                                 .append("text")
                                 .text(`Payments:  $${paymentsOriginalData}`)
-                                .attr("x", xPosition + 10)
-                                .attr("y", mousePos[1] + 40)
+                                .attr("x", xPosition + baseSize)
+                                .attr("y", mousePos[1] + stepSize * 2)
                                 .style("font-size", "0.8em")
                                 .style("fill", "white");
-                            tipGroup
-                                .append("text")
-                                .text(`Avg. Base Acres: ${baseArcesOriginalData}`)
-                                .attr("x", xPosition + 10)
-                                .attr("y", mousePos[1] + 60)
-                                .style("font-size", "0.8em")
-                                .style("fill", "white");
-                            tipGroup
-                                .append("text")
-                                .text(`Avg. Recipients:  ${recipientsOriginalData}`)
-                                .attr("x", xPosition + 10)
-                                .attr("y", mousePos[1] + 80)
-                                .style("font-size", "0.8em")
-                                .style("fill", "white");
+                            if (program === "Agriculture Risk Coverage Individual Coverage (ARC-IC)") {
+                                tipGroup
+                                    .append("text")
+                                    .text(`Avg. Recipients:  ${recipientsOriginalData}`)
+                                    .attr("x", xPosition + baseSize)
+                                    .attr("y", mousePos[1] + stepSize * 3)
+                                    .style("font-size", "0.8em")
+                                    .style("fill", "white");
+                            } else {
+                                tipGroup
+                                    .append("text")
+                                    .text(`Avg. Base Acres: ${baseArcesOriginalData}`)
+                                    .attr("x", xPosition + baseSize)
+                                    .attr("y", mousePos[1] + stepSize * 3)
+                                    .style("font-size", "0.8em")
+                                    .style("fill", "white");
+                                tipGroup
+                                    .append("text")
+                                    .text(`Avg. Recipients:  ${recipientsOriginalData}`)
+                                    .attr("x", xPosition + 10)
+                                    .attr("y", mousePos[1] + stepSize * 4)
+                                    .style("font-size", "0.8em")
+                                    .style("fill", "white");
+                            }
                         })
                         .on("mouseleave", function (e) {
                             base.selectAll(".TreeMapSquareTip").remove();

--- a/src/pages/TitleIPage.tsx
+++ b/src/pages/TitleIPage.tsx
@@ -136,7 +136,7 @@ export default function TitleIPage(): JSX.Element {
                         >
                             <Title1Map
                                 program="Total Commodities Programs"
-                                year="2018-2022"
+                                year="2014-2021"
                                 mapColor={mapColor}
                                 statePerformance={stateDistributionData}
                                 stateCodes={stateCodesData}
@@ -173,13 +173,13 @@ export default function TitleIPage(): JSX.Element {
                                 }}
                             >
                                 <Title1ProgramTable
-                                    tableTitle="Comparing Total Commodities Programs Payments and Payments Percentage Nationwide (2018-2022)"
+                                    tableTitle="Comparing Total Commodities Programs Payments and Payments Percentage Nationwide (2014-2021)"
                                     program="Total Commodities Programs"
                                     subprogram={undefined}
                                     skipColumns={[]}
                                     stateCodes={stateCodesData}
                                     Title1Data={stateDistributionData}
-                                    year="2018-2022"
+                                    year="2014-2021"
                                     color1="#F6EEEA"
                                     color2="#EAF8EA"
                                     color3="#F7F0F8"
@@ -202,7 +202,7 @@ export default function TitleIPage(): JSX.Element {
                         >
                             <Title1Map
                                 program="Agriculture Risk Coverage (ARC)"
-                                year="2018-2022"
+                                year="2014-2021"
                                 mapColor={mapColor}
                                 statePerformance={stateDistributionData}
                                 stateCodes={stateCodesData}
@@ -260,10 +260,10 @@ export default function TitleIPage(): JSX.Element {
                                             "Agriculture Risk Coverage (ARC)",
                                             undefined,
                                             stateDistributionData,
-                                            "2018-2022"
+                                            "2014-2021"
                                         )}
                                         stateCodes={stateCodesData}
-                                        year="2018-2022"
+                                        year="2014-2021"
                                         svgW={window.innerWidth * initTreeMapWidthRatio}
                                         svgH={3000}
                                     />
@@ -276,7 +276,7 @@ export default function TitleIPage(): JSX.Element {
                                         skipColumns={[]}
                                         stateCodes={stateCodesData}
                                         Title1Data={stateDistributionData}
-                                        year="2018-2022"
+                                        year="2014-2021"
                                         color1="#F6EEEA"
                                         color2="#EAF8EA"
                                         color3="#F7F0F8"
@@ -300,7 +300,7 @@ export default function TitleIPage(): JSX.Element {
                             <Title1Map
                                 program="Agriculture Risk Coverage (ARC)"
                                 subprogram="Agriculture Risk Coverage County Option (ARC-CO)"
-                                year="2018-2022"
+                                year="2014-2021"
                                 mapColor={mapColor}
                                 statePerformance={stateDistributionData}
                                 stateCodes={stateCodesData}
@@ -358,10 +358,10 @@ export default function TitleIPage(): JSX.Element {
                                             "Agriculture Risk Coverage (ARC)",
                                             "Agriculture Risk Coverage County Option (ARC-CO)",
                                             stateDistributionData,
-                                            "2018-2022"
+                                            "2014-2021"
                                         )}
                                         stateCodes={stateCodesData}
-                                        year="2018-2022"
+                                        year="2014-2021"
                                         svgW={window.innerWidth * initTreeMapWidthRatio}
                                         svgH={2800}
                                     />
@@ -374,7 +374,7 @@ export default function TitleIPage(): JSX.Element {
                                         subprogram="Agriculture Risk Coverage County Option (ARC-CO)"
                                         stateCodes={stateCodesData}
                                         Title1Data={stateDistributionData}
-                                        year="2018-2022"
+                                        year="2014-2021"
                                         color1="#F6EEEA"
                                         color2="#EAF8EA"
                                         color3="#F7F0F8"
@@ -399,7 +399,7 @@ export default function TitleIPage(): JSX.Element {
                             <Title1Map
                                 program="Agriculture Risk Coverage (ARC)"
                                 subprogram="Agriculture Risk Coverage Individual Coverage (ARC-IC)"
-                                year="2018-2022"
+                                year="2014-2021"
                                 mapColor={mapColor}
                                 statePerformance={stateDistributionData}
                                 stateCodes={stateCodesData}
@@ -457,10 +457,10 @@ export default function TitleIPage(): JSX.Element {
                                             "Agriculture Risk Coverage (ARC)",
                                             "Agriculture Risk Coverage Individual Coverage (ARC-IC)",
                                             stateDistributionData,
-                                            "2018-2022"
+                                            "2014-2021"
                                         )}
                                         stateCodes={stateCodesData}
-                                        year="2018-2022"
+                                        year="2014-2021"
                                         svgW={window.innerWidth * initTreeMapWidthRatio}
                                         svgH={2300}
                                     />
@@ -473,7 +473,7 @@ export default function TitleIPage(): JSX.Element {
                                         subprogram="Agriculture Risk Coverage Individual Coverage (ARC-IC)"
                                         stateCodes={stateCodesData}
                                         Title1Data={stateDistributionData}
-                                        year="2018-2022"
+                                        year="2014-2021"
                                         color1="#F6EEEA"
                                         color2="#EAF8EA"
                                         color3="#F7F0F8"
@@ -497,7 +497,7 @@ export default function TitleIPage(): JSX.Element {
                         >
                             <Title1Map
                                 program="Price Loss Coverage (PLC)"
-                                year="2018-2022"
+                                year="2014-2021"
                                 mapColor={mapColor}
                                 statePerformance={stateDistributionData}
                                 stateCodes={stateCodesData}
@@ -555,10 +555,10 @@ export default function TitleIPage(): JSX.Element {
                                             "Price Loss Coverage (PLC)",
                                             undefined,
                                             stateDistributionData,
-                                            "2018-2022"
+                                            "2014-2021"
                                         )}
                                         stateCodes={stateCodesData}
-                                        year="2018-2022"
+                                        year="2014-2021"
                                         svgW={window.innerWidth * initTreeMapWidthRatio}
                                         svgH={2300}
                                     />
@@ -571,7 +571,7 @@ export default function TitleIPage(): JSX.Element {
                                         skipColumns={[]}
                                         stateCodes={stateCodesData}
                                         Title1Data={stateDistributionData}
-                                        year="2018-2022"
+                                        year="2014-2021"
                                         color1="#F6EEEA"
                                         color2="#EAF8EA"
                                         color3="#F7F0F8"

--- a/src/pages/TitleIPage.tsx
+++ b/src/pages/TitleIPage.tsx
@@ -173,7 +173,7 @@ export default function TitleIPage(): JSX.Element {
                                 }}
                             >
                                 <Title1ProgramTable
-                                    tableTitle="Comparing Total Commodities Programs Payments and Payments Percentage Nationwide (2014-2021)"
+                                    tableTitle="Comparison of Total Payments for these Commodities Programs and the State's Percentage of that Total (2014-2021)"
                                     program="Total Commodities Programs"
                                     subprogram={undefined}
                                     skipColumns={[]}


### PR DESCRIPTION
Task #168. This PR includes front-end updates that Johnathan mentioned after the new title 1 update:

- Make sure all visible areas work as before
- All program maps and Title 1 maps on the landing page added the subtitle: '2022 payments for Title I have not been paid'
- Title 1 map on the landing page has 2022 data changed to 'NOT AVAILABLE', and the title changed to 2018-2021 (_After the topline API gets updated, I'll submit another PR to reflect years before 2018_)
- Title 1 page maps added the subtitle: '2022 payments for Title I have not been paid'
- Change all '2018-2022' to '2014-2021' for title 1 related maps/charts
- Treemap subtitle on title 1 page changed to 'The payments are calculated as the total of the data from 2014-2021 (2022 payment is not available); The base acres and payment recipients are calculated as the average of the data from 2014-2022.'
- Update the new legend bar to centralize the subtitle for unavailable states