### PR TITLE
0.13.0 release based on front-end development schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+- Added Google Analytics using `react-ga` module to page router [#217](https://github.com/policy-design-lab/pdl-frontend/issues/217)
+
+### Changed
+
+- Updated all maps to show exact number of dollars instead of rounding units to the nearest million [#137](https://github.com/policy-design-lab/pdl-frontend/issues/137)
+
+- Replaced the arrow of table to Material UI icons to show in Linux browser[#151](https://github.com/policy-design-lab/pdl-frontend/issues/151)
+
 ## [0.12.0] - 2023-11-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "policy-design-lab",
-      "version": "0.10.0",
+      "version": "0.12.0",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.10.4",
@@ -23,6 +23,7 @@
         "react": "^17.0.2",
         "react-apexcharts": "^1.4.0",
         "react-dom": "^17.0.2",
+        "react-ga": "^3.3.1",
         "react-horizontal-stacked-bar-chart": "^8.15.2",
         "react-router-dom": "^6.6.1",
         "react-simple-maps": "^3.0.0",
@@ -17600,6 +17601,15 @@
       },
       "peerDependencies": {
         "react": "17.0.2"
+      }
+    },
+    "node_modules/react-ga": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
+      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^15.6.2 || ^16.0 || ^17 || ^18"
       }
     },
     "node_modules/react-horizontal-stacked-bar-chart": {
@@ -36899,6 +36909,12 @@
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
       }
+    },
+    "react-ga": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
+      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
+      "requires": {}
     },
     "react-horizontal-stacked-bar-chart": {
       "version": "8.15.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react": "^17.0.2",
     "react-apexcharts": "^1.4.0",
     "react-dom": "^17.0.2",
+    "react-ga": "^3.3.1",
     "react-horizontal-stacked-bar-chart": "^8.15.2",
     "react-router-dom": "^6.6.1",
     "react-simple-maps": "^3.0.0",

--- a/src/components/LandingPageMap.tsx
+++ b/src/components/LandingPageMap.tsx
@@ -10,6 +10,7 @@ import Typography from "@mui/material/Typography";
 import "../styles/map.css";
 import DrawLegend from "./shared/DrawLegend";
 import legendConfig from "../utils/legendConfig.json";
+import { ShortFormat } from "./shared/ConvertionFormats";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
@@ -200,19 +201,7 @@ const MapChart = (props) => {
                                                         <Typography sx={{ color: "#2F7164" }}>Total Benefit</Typography>
                                                     )}
                                                     <Typography sx={{ color: "#3F3F3F" }}>
-                                                        {Math.round(Number(total / 1000000.0)) >= 0
-                                                            ? `$${Number(Math.abs(total) / 1000000.0).toLocaleString(
-                                                                  undefined,
-                                                                  {
-                                                                      maximumFractionDigits: 2
-                                                                  }
-                                                              )}M`
-                                                            : `-$${Number(Math.abs(total) / 1000000.0).toLocaleString(
-                                                                  undefined,
-                                                                  {
-                                                                      maximumFractionDigits: 2
-                                                                  }
-                                                              )}M`}
+                                                        ${ShortFormat(total, undefined, 2)}
                                                     </Typography>
                                                     <br />
                                                     {/* Show additional data on hover for SNAP */}
@@ -224,11 +213,11 @@ const MapChart = (props) => {
                                                     {/* Average SNAP monthly participation for the current years */}
                                                     {title === "Supplemental Nutrition Assistance Program (SNAP)" && (
                                                         <Typography sx={{ color: "#3F3F3F" }}>
-                                                            {Number(
-                                                                totalAverageMonthlyParticipation / yearList.length
-                                                            ).toLocaleString(undefined, {
-                                                                maximumFractionDigits: 0
-                                                            })}
+                                                            {ShortFormat(
+                                                                totalAverageMonthlyParticipation / yearList.length,
+                                                                undefined,
+                                                                2
+                                                            )}
                                                         </Typography>
                                                     )}
                                                 </Box>
@@ -247,17 +236,7 @@ const MapChart = (props) => {
                                                                     }
                                                                 >
                                                                     {record["Fiscal Year"]}:{" "}
-                                                                    {Number(record.Amount / 1000000.0) >= 0
-                                                                        ? `$${Number(
-                                                                              Math.abs(record.Amount) / 1000000.0
-                                                                          ).toLocaleString(undefined, {
-                                                                              maximumFractionDigits: 2
-                                                                          })}M`
-                                                                        : `-$${Number(
-                                                                              Math.abs(record.Amount) / 1000000.0
-                                                                          ).toLocaleString(undefined, {
-                                                                              maximumFractionDigits: 2
-                                                                          })}M`}
+                                                                    {ShortFormat(record.Amount, undefined, 2)}
                                                                 </div>
                                                             ))}
                                                         </Typography>
@@ -278,20 +257,8 @@ const MapChart = (props) => {
                                                                         <div>2022: Not Available</div>
                                                                     ) : (
                                                                         <div>
-                                                                            {record["Fiscal Year"]}:{" "}
-                                                                            {Number(record.Amount / 1000000.0) >= 0
-                                                                                ? `$${Number(
-                                                                                      Math.abs(record.Amount) /
-                                                                                          1000000.0
-                                                                                  ).toLocaleString(undefined, {
-                                                                                      maximumFractionDigits: 2
-                                                                                  })}M`
-                                                                                : `-$${Number(
-                                                                                      Math.abs(record.Amount) /
-                                                                                          1000000.0
-                                                                                  ).toLocaleString(undefined, {
-                                                                                      maximumFractionDigits: 2
-                                                                                  })}M`}
+                                                                            {record["Fiscal Year"]}: $
+                                                                            {ShortFormat(record.Amount, undefined, 2)}
                                                                         </div>
                                                                     )}
                                                                 </div>
@@ -315,19 +282,7 @@ const MapChart = (props) => {
                                                     </Typography>
                                                     <Typography sx={{ color: "#2F7164" }}>Total Benefit</Typography>
                                                     <Typography sx={{ color: "#3F3F3F" }}>
-                                                        {Math.round(Number(total / 1000000.0)) >= 0
-                                                            ? `$${Number(Math.abs(total) / 1000000.0).toLocaleString(
-                                                                  undefined,
-                                                                  {
-                                                                      maximumFractionDigits: 2
-                                                                  }
-                                                              )}M`
-                                                            : `-$${Number(Math.abs(total) / 1000000.0).toLocaleString(
-                                                                  undefined,
-                                                                  {
-                                                                      maximumFractionDigits: 2
-                                                                  }
-                                                              )}M`}
+                                                        ${ShortFormat(total, undefined, 2)}
                                                     </Typography>
                                                 </Box>
                                                 <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
@@ -337,80 +292,40 @@ const MapChart = (props) => {
                                                         <br />
                                                         {records.map((record) => (
                                                             <div key={record.State}>
-                                                                2018:{" "}
-                                                                {record["2018 All Programs Total"] / 1000000.0 >= 0
-                                                                    ? `$${Number(
-                                                                          Math.abs(record["2018 All Programs Total"]) /
-                                                                              1000000.0
-                                                                      ).toLocaleString(undefined, {
-                                                                          maximumFractionDigits: 2
-                                                                      })}M`
-                                                                    : `-$${Number(
-                                                                          Math.abs(record["2018 All Programs Total"]) /
-                                                                              1000000.0
-                                                                      ).toLocaleString(undefined, {
-                                                                          maximumFractionDigits: 2
-                                                                      })}M`}
+                                                                2018: $
+                                                                {ShortFormat(
+                                                                    record["2018 All Programs Total"],
+                                                                    undefined,
+                                                                    2
+                                                                )}
                                                                 <br />
-                                                                2019:{" "}
-                                                                {record["2019 All Programs Total"] / 1000000.0 >= 0
-                                                                    ? `$${Number(
-                                                                          Math.abs(record["2019 All Programs Total"]) /
-                                                                              1000000.0
-                                                                      ).toLocaleString(undefined, {
-                                                                          maximumFractionDigits: 2
-                                                                      })}M`
-                                                                    : `-$${Number(
-                                                                          Math.abs(record["2019 All Programs Total"]) /
-                                                                              1000000.0
-                                                                      ).toLocaleString(undefined, {
-                                                                          maximumFractionDigits: 2
-                                                                      })}M`}
+                                                                2019: $
+                                                                {ShortFormat(
+                                                                    record["2019 All Programs Total"],
+                                                                    undefined,
+                                                                    2
+                                                                )}
                                                                 <br />
-                                                                2020:{" "}
-                                                                {record["2020 All Programs Total"] / 1000000.0 >= 0
-                                                                    ? `$${Number(
-                                                                          Math.abs(record["2020 All Programs Total"]) /
-                                                                              1000000.0
-                                                                      ).toLocaleString(undefined, {
-                                                                          maximumFractionDigits: 2
-                                                                      })}M`
-                                                                    : `-$${Number(
-                                                                          Math.abs(record["2020 All Programs Total"]) /
-                                                                              1000000.0
-                                                                      ).toLocaleString(undefined, {
-                                                                          maximumFractionDigits: 2
-                                                                      })}M`}
+                                                                2020: $
+                                                                {ShortFormat(
+                                                                    record["2020 All Programs Total"],
+                                                                    undefined,
+                                                                    2
+                                                                )}
                                                                 <br />
-                                                                2021:{" "}
-                                                                {record["2021 All Programs Total"] / 1000000.0 >= 0
-                                                                    ? `$${Number(
-                                                                          Math.abs(record["2021 All Programs Total"]) /
-                                                                              1000000.0
-                                                                      ).toLocaleString(undefined, {
-                                                                          maximumFractionDigits: 2
-                                                                      })}M`
-                                                                    : `-$${Number(
-                                                                          Math.abs(record["2021 All Programs Total"]) /
-                                                                              1000000.0
-                                                                      ).toLocaleString(undefined, {
-                                                                          maximumFractionDigits: 2
-                                                                      })}M`}
+                                                                2021: $
+                                                                {ShortFormat(
+                                                                    record["2021 All Programs Total"],
+                                                                    undefined,
+                                                                    2
+                                                                )}
                                                                 <br />
-                                                                2022:{" "}
-                                                                {record["2022 All Programs Total"] / 1000000.0 >= 0
-                                                                    ? `$${Number(
-                                                                          Math.abs(record["2022 All Programs Total"]) /
-                                                                              1000000.0
-                                                                      ).toLocaleString(undefined, {
-                                                                          maximumFractionDigits: 2
-                                                                      })}M`
-                                                                    : `-$${Number(
-                                                                          Math.abs(record["2022 All Programs Total"]) /
-                                                                              1000000.0
-                                                                      ).toLocaleString(undefined, {
-                                                                          maximumFractionDigits: 2
-                                                                      })}M`}
+                                                                2022: $
+                                                                {ShortFormat(
+                                                                    record["2022 All Programs Total"],
+                                                                    undefined,
+                                                                    2
+                                                                )}
                                                                 <br />
                                                             </div>
                                                         ))}

--- a/src/components/SemiDonutChart.tsx
+++ b/src/components/SemiDonutChart.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { PieChart, Pie, Tooltip, Label, Cell } from "recharts";
 import { Box } from "@mui/material";
+import { ShortFormat } from "./shared/ConvertionFormats";
 
 const RADIAN = Math.PI / 180;
 
@@ -66,15 +67,7 @@ export default function SemiDonutChart({ data, label1, label2 }: any): JSX.Eleme
                     label={renderCustomizedLabel}
                 >
                     <Label
-                        value={
-                            Number(label1) >= 1000000000
-                                ? `$${Number(Number(label1) / 1000000000.0).toLocaleString(undefined, {
-                                      maximumFractionDigits: 2
-                                  })}B`
-                                : `$${Number(Number(label1) / 1000000.0).toLocaleString(undefined, {
-                                      maximumFractionDigits: 2
-                                  })}M`
-                        }
+                        value={`$${ShortFormat(Number(label1), undefined, 2)}`}
                         position="center"
                         dy={-75}
                         style={{ textAnchor: "middle", fontSize: "200%", fill: "rgba(0, 0, 0, 0.87)" }}

--- a/src/components/acep/ACEPCategoryMap.tsx
+++ b/src/components/acep/ACEPCategoryMap.tsx
@@ -72,18 +72,7 @@ const MapChart = (props) => {
                                                 }}
                                             >
                                                 <Typography sx={{ color: "#3F3F3F" }}>
-                                                    {Number(categoryPayment) < 1000000
-                                                        ? `$${Number(Number(categoryPayment) / 1000.0).toLocaleString(
-                                                              undefined,
-                                                              {
-                                                                  maximumFractionDigits: 2
-                                                              }
-                                                          )}K`
-                                                        : `$${Number(
-                                                              Number(categoryPayment) / 1000000.0
-                                                          ).toLocaleString(undefined, {
-                                                              maximumFractionDigits: 2
-                                                          })}M`}
+                                                    ${ShortFormat(categoryPayment, undefined, 2)}
                                                 </Typography>
                                                 <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                 <Typography sx={{ color: "#3F3F3F" }}>

--- a/src/components/acep/ACEPTable.tsx
+++ b/src/components/acep/ACEPTable.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy, usePagination } from "react-table";
 import { Grid, TableContainer, Typography, Box } from "@mui/material";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import {
     compareWithNumber,
     compareWithAlphabetic,
@@ -283,7 +284,7 @@ function Table({ columns, data, initialState }: { columns: any; data: any; initi
                                             if (!column.isSorted)
                                                 return (
                                                     <Box className="tableArrow" sx={{ display: "inline" }}>
-                                                        {"\u{2B83}"}
+                                                        <SwapVertIcon />
                                                     </Box>
                                                 );
                                             if (column.isSortedDesc)

--- a/src/components/acep/ACEPTotalMap.tsx
+++ b/src/components/acep/ACEPTotalMap.tsx
@@ -10,6 +10,7 @@ import PropTypes from "prop-types";
 import "../../styles/map.css";
 import legendConfig from "../../utils/legendConfig.json";
 import DrawLegend from "../shared/DrawLegend";
+import { ShortFormat } from "../shared/ConvertionFormats";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
@@ -63,17 +64,7 @@ const MapChart = (props) => {
                                                     }}
                                                 >
                                                     <Typography sx={{ color: "#3F3F3F" }}>
-                                                        {Number(totalPaymentInDollars) < 1000000
-                                                            ? `$${Number(
-                                                                  Number(totalPaymentInDollars) / 1000.0
-                                                              ).toLocaleString(undefined, {
-                                                                  maximumFractionDigits: 2
-                                                              })}K`
-                                                            : `$${Number(
-                                                                  Number(totalPaymentInDollars) / 1000000.0
-                                                              ).toLocaleString(undefined, {
-                                                                  maximumFractionDigits: 2
-                                                              })}M`}
+                                                        ${ShortFormat(totalPaymentInDollars, undefined, 2)}
                                                     </Typography>
                                                     <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                     <Typography sx={{ color: "#3F3F3F" }}>

--- a/src/components/cropinsurance/CropInsuranceTable.tsx
+++ b/src/components/cropinsurance/CropInsuranceTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy, usePagination } from "react-table";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import { Grid, TableContainer, Typography, Box } from "@mui/material";
 import {
     compareWithNumber,
@@ -256,7 +257,11 @@ function Table({ columns, data, initialState }: { columns: any; data: any; initi
                                     <span>
                                         {(() => {
                                             if (!column.isSorted)
-                                                return <Box sx={{ ml: 1, display: "inline" }}>{"\u{2B83}"}</Box>;
+                                                return (
+                                                    <Box sx={{ ml: 1, display: "inline" }}>
+                                                        <SwapVertIcon />
+                                                    </Box>
+                                                );
                                             if (column.isSortedDesc)
                                                 return <Box sx={{ ml: 1, display: "inline" }}>{"\u{25BC}"}</Box>;
                                             return <Box sx={{ ml: 1, display: "inline" }}>{"\u{25B2}"}</Box>;

--- a/src/components/crp/CRPTotalMap.tsx
+++ b/src/components/crp/CRPTotalMap.tsx
@@ -11,6 +11,7 @@ import "../../styles/map.css";
 import legendConfig from "../../utils/legendConfig.json";
 import DrawLegend from "../shared/DrawLegend";
 import { getValueFromAttrDollar } from "../../utils/apiutil";
+import { ShortFormat } from "../shared/ConvertionFormats";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
@@ -64,17 +65,7 @@ const MapChart = (props) => {
                                                     }}
                                                 >
                                                     <Typography sx={{ color: "#3F3F3F" }}>
-                                                        {Number(totalPaymentInDollars) < 1000000
-                                                            ? `$${Number(
-                                                                  Number(totalPaymentInDollars) / 1000.0
-                                                              ).toLocaleString(undefined, {
-                                                                  maximumFractionDigits: 2
-                                                              })}K`
-                                                            : `$${Number(
-                                                                  Number(totalPaymentInDollars) / 1000000.0
-                                                              ).toLocaleString(undefined, {
-                                                                  maximumFractionDigits: 2
-                                                              })}M`}
+                                                        ${ShortFormat(totalPaymentInDollars, undefined, 2)}
                                                     </Typography>
                                                     <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                     <Typography sx={{ color: "#3F3F3F" }}>

--- a/src/components/crp/CRPTotalTable.tsx
+++ b/src/components/crp/CRPTotalTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy } from "react-table";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import Box from "@mui/material/Box";
 import "../../styles/table.css";
 
@@ -82,7 +83,12 @@ function Table({ columns, data }: { columns: any; data: any }) {
                                         {column.render("Header")}
                                         <div>
                                             {(() => {
-                                                if (!column.isSorted) return <Box sx={{ ml: 1 }}>{"\u{2B83}"}</Box>;
+                                                if (!column.isSorted)
+                                                    return (
+                                                        <Box sx={{ ml: 1 }}>
+                                                            <SwapVertIcon />
+                                                        </Box>
+                                                    );
                                                 if (column.isSortedDesc) return <Box sx={{ ml: 1 }}>{"\u{25BC}"}</Box>;
                                                 return <Box sx={{ ml: 1 }}>{"\u{25B2}"}</Box>;
                                             })()}

--- a/src/components/crp/CategoryMap.tsx
+++ b/src/components/crp/CategoryMap.tsx
@@ -12,6 +12,7 @@ import "../../styles/map.css";
 import legendConfig from "../../utils/legendConfig.json";
 import DrawLegend from "../shared/DrawLegend";
 import { getValueFromAttrDollar } from "../../utils/apiutil";
+import { ShortFormat } from "../shared/ConvertionFormats";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
@@ -100,18 +101,7 @@ const MapChart = (props) => {
                                                 }}
                                             >
                                                 <Typography sx={{ color: "#3F3F3F" }}>
-                                                    {Number(categoryPayment) < 1000000
-                                                        ? `$${Number(Number(categoryPayment) / 1000.0).toLocaleString(
-                                                              undefined,
-                                                              {
-                                                                  maximumFractionDigits: 2
-                                                              }
-                                                          )}K`
-                                                        : `$${Number(
-                                                              Number(categoryPayment) / 1000000.0
-                                                          ).toLocaleString(undefined, {
-                                                              maximumFractionDigits: 2
-                                                          })}M`}
+                                                    ${ShortFormat(categoryPayment, undefined, 2)}
                                                 </Typography>
                                                 <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                 <Typography sx={{ color: "#3F3F3F" }}>

--- a/src/components/crp/CategoryTable.tsx
+++ b/src/components/crp/CategoryTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy } from "react-table";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import Box from "@mui/material/Box";
 import "../../styles/table.css";
 
@@ -83,7 +84,12 @@ function Table({ columns, data }: { columns: any; data: any; statePerformance: a
                                         {column.render("Header")}
                                         <div>
                                             {(() => {
-                                                if (!column.isSorted) return <Box sx={{ ml: 1 }}>{"\u{2B83}"}</Box>;
+                                                if (!column.isSorted)
+                                                    return (
+                                                        <Box sx={{ ml: 1 }}>
+                                                            <SwapVertIcon />
+                                                        </Box>
+                                                    );
                                                 if (column.isSortedDesc) return <Box sx={{ ml: 1 }}>{"\u{25BC}"}</Box>;
                                                 return <Box sx={{ ml: 1 }}>{"\u{25B2}"}</Box>;
                                             })()}

--- a/src/components/csp/CSPTotalMap.tsx
+++ b/src/components/csp/CSPTotalMap.tsx
@@ -10,6 +10,7 @@ import PropTypes from "prop-types";
 import "../../styles/map.css";
 import legendConfig from "../../utils/legendConfig.json";
 import DrawLegend from "../shared/DrawLegend";
+import { ShortFormat } from "../shared/ConvertionFormats";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
@@ -61,17 +62,7 @@ const MapChart = (props) => {
                                                     }}
                                                 >
                                                     <Typography sx={{ color: "#3F3F3F" }}>
-                                                        {Number(totalPaymentInDollars) < 1000000
-                                                            ? `$${Number(
-                                                                  Number(totalPaymentInDollars) / 1000.0
-                                                              ).toLocaleString(undefined, {
-                                                                  maximumFractionDigits: 2
-                                                              })}K`
-                                                            : `$${Number(
-                                                                  Number(totalPaymentInDollars) / 1000000.0
-                                                              ).toLocaleString(undefined, {
-                                                                  maximumFractionDigits: 2
-                                                              })}M`}
+                                                        ${ShortFormat(totalPaymentInDollars, undefined, 2)}
                                                     </Typography>
                                                     <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                     <Typography sx={{ color: "#3F3F3F" }}>

--- a/src/components/csp/CSPTotalTable.tsx
+++ b/src/components/csp/CSPTotalTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy } from "react-table";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import Box from "@mui/material/Box";
 import "../../styles/table.css";
 
@@ -81,7 +82,12 @@ function Table({ columns, data }: { columns: any; data: any }) {
                                         {column.render("Header")}
                                         <div>
                                             {(() => {
-                                                if (!column.isSorted) return <Box sx={{ ml: 1 }}>{"\u{2B83}"}</Box>;
+                                                if (!column.isSorted)
+                                                    return (
+                                                        <Box sx={{ ml: 1 }}>
+                                                            <SwapVertIcon />
+                                                        </Box>
+                                                    );
                                                 if (column.isSortedDesc) return <Box sx={{ ml: 1 }}>{"\u{25BC}"}</Box>;
                                                 return <Box sx={{ ml: 1 }}>{"\u{25B2}"}</Box>;
                                             })()}

--- a/src/components/csp/CategoryMap.tsx
+++ b/src/components/csp/CategoryMap.tsx
@@ -11,6 +11,7 @@ import * as d3 from "d3";
 import "../../styles/map.css";
 import legendConfig from "../../utils/legendConfig.json";
 import DrawLegend from "../shared/DrawLegend";
+import { ShortFormat } from "../shared/ConvertionFormats";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
@@ -82,18 +83,7 @@ const MapChart = (props) => {
                                                 }}
                                             >
                                                 <Typography sx={{ color: "#3F3F3F" }}>
-                                                    {Number(categoryPayment) < 1000000
-                                                        ? `$${Number(Number(categoryPayment) / 1000.0).toLocaleString(
-                                                              undefined,
-                                                              {
-                                                                  maximumFractionDigits: 2
-                                                              }
-                                                          )}K`
-                                                        : `$${Number(
-                                                              Number(categoryPayment) / 1000000.0
-                                                          ).toLocaleString(undefined, {
-                                                              maximumFractionDigits: 2
-                                                          })}M`}
+                                                    ${ShortFormat(categoryPayment, undefined, 2)}
                                                 </Typography>
                                                 <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                 <Typography sx={{ color: "#3F3F3F" }}>

--- a/src/components/csp/CategoryTable.tsx
+++ b/src/components/csp/CategoryTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy } from "react-table";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import Box from "@mui/material/Box";
 import "../../styles/table.css";
 
@@ -82,7 +83,12 @@ function Table({ columns, data }: { columns: any; data: any; statePerformance: a
                                         {column.render("Header")}
                                         <div>
                                             {(() => {
-                                                if (!column.isSorted) return <Box sx={{ ml: 1 }}>{"\u{2B83}"}</Box>;
+                                                if (!column.isSorted)
+                                                    return (
+                                                        <Box sx={{ ml: 1 }}>
+                                                            <SwapVertIcon />
+                                                        </Box>
+                                                    );
                                                 if (column.isSortedDesc) return <Box sx={{ ml: 1 }}>{"\u{25BC}"}</Box>;
                                                 return <Box sx={{ ml: 1 }}>{"\u{25B2}"}</Box>;
                                             })()}

--- a/src/components/eqip/CategoryMap.tsx
+++ b/src/components/eqip/CategoryMap.tsx
@@ -10,6 +10,7 @@ import * as d3 from "d3";
 import "../../styles/map.css";
 import legendConfig from "../../utils/legendConfig.json";
 import DrawLegend from "../shared/DrawLegend";
+import { ShortFormat } from "../shared/ConvertionFormats";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
@@ -66,17 +67,7 @@ const MapChart = (props) => {
                                                     }}
                                                 >
                                                     <Typography sx={{ color: "#3F3F3F" }}>
-                                                        {Number(categoryPayment) < 1000000
-                                                            ? `$${Number(
-                                                                  Number(categoryPayment) / 1000.0
-                                                              ).toLocaleString(undefined, {
-                                                                  maximumFractionDigits: 2
-                                                              })}K`
-                                                            : `$${Number(
-                                                                  Number(categoryPayment) / 1000000.0
-                                                              ).toLocaleString(undefined, {
-                                                                  maximumFractionDigits: 2
-                                                              })}M`}
+                                                        ${ShortFormat(categoryPayment, undefined, 2)}
                                                     </Typography>
                                                     <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                     <Typography sx={{ color: "#3F3F3F" }}>

--- a/src/components/eqip/CategoryTable.tsx
+++ b/src/components/eqip/CategoryTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy } from "react-table";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import Box from "@mui/material/Box";
 import "../../styles/table.css";
 
@@ -82,7 +83,12 @@ function Table({ columns, data, statePerformance }: { columns: any; data: any; s
                                         {column.render("Header")}
                                         <div>
                                             {(() => {
-                                                if (!column.isSorted) return <Box sx={{ ml: 1 }}>{"\u{2B83}"}</Box>;
+                                                if (!column.isSorted)
+                                                    return (
+                                                        <Box sx={{ ml: 1 }}>
+                                                            <SwapVertIcon />
+                                                        </Box>
+                                                    );
                                                 if (column.isSortedDesc) return <Box sx={{ ml: 1 }}>{"\u{25BC}"}</Box>;
                                                 return <Box sx={{ ml: 1 }}>{"\u{25B2}"}</Box>;
                                             })()}

--- a/src/components/eqip/EQIPTotalMap.tsx
+++ b/src/components/eqip/EQIPTotalMap.tsx
@@ -11,6 +11,7 @@ import PropTypes from "prop-types";
 import "../../styles/map.css";
 import legendConfig from "../../utils/legendConfig.json";
 import DrawLegend from "../shared/DrawLegend";
+import { ShortFormat } from "../shared/ConvertionFormats";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
@@ -58,17 +59,7 @@ const MapChart = ({ setTooltipContent, maxValue, allStates, statePerformance, co
                                                 }}
                                             >
                                                 <Typography sx={{ color: "#3F3F3F" }}>
-                                                    {Number(totalPaymentInDollars) < 1000000
-                                                        ? `$${Number(
-                                                              Number(totalPaymentInDollars) / 1000.0
-                                                          ).toLocaleString(undefined, {
-                                                              maximumFractionDigits: 2
-                                                          })}K`
-                                                        : `$${Number(
-                                                              Number(totalPaymentInDollars) / 1000000.0
-                                                          ).toLocaleString(undefined, {
-                                                              maximumFractionDigits: 2
-                                                          })}M`}
+                                                    ${ShortFormat(totalPaymentInDollars, undefined, 2)}
                                                 </Typography>
                                                 <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                 <Typography sx={{ color: "#3F3F3F" }}>

--- a/src/components/eqip/EQIPTotalTable.tsx
+++ b/src/components/eqip/EQIPTotalTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy } from "react-table";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import Box from "@mui/material/Box";
 import "../../styles/table.css";
 
@@ -81,7 +82,12 @@ function Table({ columns, data }: { columns: any; data: any }) {
                                         {column.render("Header")}
                                         <div>
                                             {(() => {
-                                                if (!column.isSorted) return <Box sx={{ ml: 1 }}>{"\u{2B83}"}</Box>;
+                                                if (!column.isSorted)
+                                                    return (
+                                                        <Box sx={{ ml: 1 }}>
+                                                            <SwapVertIcon />
+                                                        </Box>
+                                                    );
                                                 if (column.isSortedDesc) return <Box sx={{ ml: 1 }}>{"\u{25BC}"}</Box>;
                                                 return <Box sx={{ ml: 1 }}>{"\u{25B2}"}</Box>;
                                             })()}

--- a/src/components/rcpp/RCPPTotalMap.tsx
+++ b/src/components/rcpp/RCPPTotalMap.tsx
@@ -11,6 +11,7 @@ import "../../styles/map.css";
 import legendConfig from "../../utils/legendConfig.json";
 import DrawLegend from "../shared/DrawLegend";
 import { getValueFromAttrDollar } from "../../utils/apiutil";
+import { ShortFormat } from "../shared/ConvertionFormats";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
@@ -65,17 +66,7 @@ const MapChart = (props) => {
                                                     }}
                                                 >
                                                     <Typography sx={{ color: "#3F3F3F" }}>
-                                                        {Number(totalPaymentInDollars) < 1000000
-                                                            ? `$${Number(
-                                                                  Number(totalPaymentInDollars) / 1000.0
-                                                              ).toLocaleString(undefined, {
-                                                                  maximumFractionDigits: 2
-                                                              })}K`
-                                                            : `$${Number(
-                                                                  Number(totalPaymentInDollars) / 1000000.0
-                                                              ).toLocaleString(undefined, {
-                                                                  maximumFractionDigits: 2
-                                                              })}M`}
+                                                        ${ShortFormat(totalPaymentInDollars, undefined, 2)}
                                                     </Typography>
                                                     <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                     <Typography sx={{ color: "#3F3F3F" }}>

--- a/src/components/rcpp/RCPPTotalTable.tsx
+++ b/src/components/rcpp/RCPPTotalTable.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy } from "react-table";
 import Box from "@mui/material/Box";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import "../../styles/table.css";
 import { compareWithDollarSign, compareWithNumber } from "../shared/TableCompareFunctions";
 
@@ -82,7 +83,12 @@ function Table({ columns, data }: { columns: any; data: any }) {
                                         {column.render("Header")}
                                         <div>
                                             {(() => {
-                                                if (!column.isSorted) return <Box sx={{ ml: 1 }}>{"\u{2B83}"}</Box>;
+                                                if (!column.isSorted)
+                                                    return (
+                                                        <Box sx={{ ml: 1 }}>
+                                                            <SwapVertIcon />
+                                                        </Box>
+                                                    );
                                                 if (column.isSortedDesc) return <Box sx={{ ml: 1 }}>{"\u{25BC}"}</Box>;
                                                 return <Box sx={{ ml: 1 }}>{"\u{25B2}"}</Box>;
                                             })()}

--- a/src/components/shared/ConvertionFormats.tsx
+++ b/src/components/shared/ConvertionFormats.tsx
@@ -1,21 +1,35 @@
-export function ShortFormat(labelValue, position?: number) {
+/**
+ *
+ * @param labelValue
+ * @param position: put undefined if no preference of floor or ceiling
+ * @param decimals: if not defined, use 1 decimal place
+ * @returns
+ */
+export function ShortFormat(labelValue, position?: number, decimal?: number) {
     const absoluteValue = Math.abs(Number.parseFloat(labelValue));
     let decimalPart = "";
     let result = "";
+    const decimals = !decimal ? 1 : decimal;
     if (absoluteValue >= 1.0e9) {
         result =
-            (absoluteValue / 1.0e9) % 1 !== 0 ? `${(absoluteValue / 1.0e9).toFixed(1)}B` : `${absoluteValue / 1.0e9}B`;
+            (absoluteValue / 1.0e9) % 1 !== 0
+                ? `${(absoluteValue / 1.0e9).toFixed(decimals)}B`
+                : `${absoluteValue / 1.0e9}B`;
         decimalPart = (absoluteValue / 1.0e9) % 1 !== 0 ? result.match(/\.(.*)B$/)[1] : "";
     } else if (absoluteValue >= 1.0e6) {
         result =
-            (absoluteValue / 1.0e6) % 1 !== 0 ? `${(absoluteValue / 1.0e6).toFixed(1)}M` : `${absoluteValue / 1.0e6}M`;
+            (absoluteValue / 1.0e6) % 1 !== 0
+                ? `${(absoluteValue / 1.0e6).toFixed(decimals)}M`
+                : `${absoluteValue / 1.0e6}M`;
         decimalPart = (absoluteValue / 1.0e6) % 1 !== 0 ? result.match(/\.(.*)M$/)[1] : "";
     } else if (absoluteValue >= 1.0e3) {
         result =
-            (absoluteValue / 1.0e3) % 1 !== 0 ? `${(absoluteValue / 1.0e3).toFixed(1)}K` : `${absoluteValue / 1.0e3}K`;
+            (absoluteValue / 1.0e3) % 1 !== 0
+                ? `${(absoluteValue / 1.0e3).toFixed(decimals)}K`
+                : `${absoluteValue / 1.0e3}K`;
         decimalPart = (absoluteValue / 1.0e3) % 1 !== 0 ? result.match(/\.(.*)K$/)[1] : "";
     } else {
-        result = absoluteValue % 1 !== 0 ? `${absoluteValue.toFixed(1)}` : `${absoluteValue}`;
+        result = absoluteValue % 1 !== 0 ? `${absoluteValue.toFixed(decimals)}` : `${absoluteValue}`;
     }
     if (labelValue.toString().includes("-")) {
         result = `-${result}`;

--- a/src/components/snap/SNAPTable.tsx
+++ b/src/components/snap/SNAPTable.tsx
@@ -2,6 +2,7 @@ import { Typography } from "@mui/material";
 import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy, usePagination } from "react-table";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import Box from "@mui/material/Box";
 import { compareWithAlphabetic, compareWithDollarSign, compareWithPercentSign } from "../shared/TableCompareFunctions";
 import "../../styles/table.css";
@@ -211,7 +212,11 @@ function Table({ columns, data, initialState }: { columns: any; data: any; initi
                                     <span>
                                         {(() => {
                                             if (!column.isSorted)
-                                                return <Box sx={{ ml: 1, display: "inline" }}>{"\u{2B83}"}</Box>;
+                                                return (
+                                                    <Box sx={{ ml: 1, display: "inline" }}>
+                                                        <SwapVertIcon />
+                                                    </Box>
+                                                );
                                             if (column.isSortedDesc)
                                                 return <Box sx={{ ml: 1, display: "inline" }}>{"\u{25BC}"}</Box>;
                                             return <Box sx={{ ml: 1, display: "inline" }}>{"\u{25B2}"}</Box>;

--- a/src/components/title1/Title1Map.tsx
+++ b/src/components/title1/Title1Map.tsx
@@ -10,6 +10,7 @@ import PropTypes from "prop-types";
 import "../../styles/map.css";
 import DrawLegend from "../shared/DrawLegend";
 import legendConfig from "../../utils/legendConfig.json";
+import { ShortFormat } from "../shared/ConvertionFormats";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
@@ -82,11 +83,7 @@ const MapChart = ({
 
                                                 {subprogram === undefined ? (
                                                     <Typography sx={{ color: "#3F3F3F" }}>
-                                                        $
-                                                        {Number(programPayment / 1000000.0).toLocaleString(undefined, {
-                                                            maximumFractionDigits: 2
-                                                        })}
-                                                        M
+                                                        ${ShortFormat(programPayment, undefined, 2)}
                                                     </Typography>
                                                 ) : (
                                                     <Box
@@ -96,14 +93,7 @@ const MapChart = ({
                                                         }}
                                                     >
                                                         <Typography sx={{ color: "#3F3F3F" }}>
-                                                            $
-                                                            {Number(programPayment / 1000000.0).toLocaleString(
-                                                                undefined,
-                                                                {
-                                                                    maximumFractionDigits: 2
-                                                                }
-                                                            )}
-                                                            M
+                                                            ${ShortFormat(programPayment, undefined, 2)}
                                                         </Typography>
                                                         <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                         <Typography sx={{ color: "#3F3F3F" }}>
@@ -208,11 +198,7 @@ const MapChart = ({
 
                                                 {subprogram === undefined ? (
                                                     <Typography sx={{ color: "#3F3F3F" }}>
-                                                        $
-                                                        {Number(programPayment / 1000000.0).toLocaleString(undefined, {
-                                                            maximumFractionDigits: 2
-                                                        })}
-                                                        M
+                                                        ${ShortFormat(programPayment, undefined, 2)}
                                                     </Typography>
                                                 ) : (
                                                     <Box
@@ -222,14 +208,7 @@ const MapChart = ({
                                                         }}
                                                     >
                                                         <Typography sx={{ color: "#3F3F3F" }}>
-                                                            $
-                                                            {Number(programPayment / 1000000.0).toLocaleString(
-                                                                undefined,
-                                                                {
-                                                                    maximumFractionDigits: 2
-                                                                }
-                                                            )}
-                                                            M
+                                                            ${ShortFormat(programPayment, undefined, 2)}
                                                         </Typography>
                                                         <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
                                                         <Typography sx={{ color: "#3F3F3F" }}>

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useTable, useSortBy, usePagination } from "react-table";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import { Grid, TableContainer, Typography, Box } from "@mui/material";
 import {
     compareWithNumber,
@@ -669,7 +670,11 @@ function Table({ columns, data, initialState }: { columns: any; data: any; initi
                                     <span>
                                         {(() => {
                                             if (!column.isSorted)
-                                                return <Box sx={{ ml: 1, display: "inline" }}>{"\u{2B83}"}</Box>;
+                                                return (
+                                                    <Box sx={{ ml: 1, display: "inline" }}>
+                                                        <SwapVertIcon />
+                                                    </Box>
+                                                );
                                             if (column.isSortedDesc)
                                                 return <Box sx={{ ml: 1, display: "inline" }}>{"\u{25BC}"}</Box>;
                                             return <Box sx={{ ml: 1, display: "inline" }}>{"\u{25B2}"}</Box>;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
+import ReactGA from "react-ga";
 import LandingPage from "./pages/LandingPage";
 import EQIPPage from "./pages/EQIPPage";
 import CSPPage from "./pages/CSPPage";
@@ -11,6 +12,9 @@ import CropInsurancePage from "./pages/CropInsurancePage";
 import ACEPPage from "./pages/ACEPPage";
 import IssueWhitePaperPage from "./pages/IssueWhitePaperPage";
 
+const TRACKING_ID = "G-GFR8PTXMDM";
+ReactGA.initialize(TRACKING_ID);
+
 const ScrollToTop = (props: any) => {
     const location = useLocation();
     useEffect(() => {
@@ -21,6 +25,10 @@ const ScrollToTop = (props: any) => {
 };
 
 export default function Main(): JSX.Element {
+    useEffect(() => {
+        ReactGA.pageview(window.location.pathname + window.location.search);
+    }, []);
+
     return (
         <ScrollToTop>
             <Routes>


### PR DESCRIPTION
This PR is for 0.13.0 release.

As planned, 0.13.0 will be the last release before Christmas break and include the following three updates:
![Screenshot 2023-12-08 at 9 10 15 AM](https://github.com/policy-design-lab/pdl-frontend/assets/92752107/34440deb-235a-49d5-bcbe-397b6ca5dae5)

- Added Google Analytics using `react-ga` module to page router [#217](https://github.com/policy-design-lab/pdl-frontend/issues/217)

- Updated all maps to show exact number of dollars instead of rounding units to the nearest million [#137](https://github.com/policy-design-lab/pdl-frontend/issues/137)

- Replaced the arrow of table to Material UI icons to show in Linux browser[#151](https://github.com/policy-design-lab/pdl-frontend/issues/151)