### PR TITLE
#263 and #266: update urls of Policy Lab page and Issue/White Paper page, and remove copyright on Policy Lab page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+- Removed the 'Copyright' section of the Policy Lab page [#263](https://github.com/policy-design-lab/pdl-frontend/issues/263)
+- Changed the '_' in the URLs of the Policy Lab page and Issue/White Page page to '-' [#266](https://github.com/policy-design-lab/pdl-frontend/issues/266)
+
 ## [0.17.0] - 2024-04-09
 
 ### Added

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -18,8 +18,8 @@ import PDLLogo from "./PDLLogo";
 const drawerWidth = 240;
 const navItems = [
     { title: "HOME", link: "/" },
-    { title: "POLICY LAB".toUpperCase(), link: "/policy_lab" },
-    { title: "ISSUES & WHITE PAPERS", link: "/issue_whitepaper" },
+    { title: "POLICY LAB".toUpperCase(), link: "/policy-lab" },
+    { title: "ISSUES & WHITE PAPERS", link: "/issue-whitepaper" },
     { title: "ABOUT PDL" }
 ];
 export default function NavBar({

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ import CropInsurancePage from "./pages/CropInsurancePage";
 import ACEPPage from "./pages/ACEPPage";
 import IssueWhitePaperPage from "./pages/IssueWhitePaperPage";
 import TitleIIPage from "./pages/TitleIIPage";
-import Surface51Page from "./pages/Surface51Page";
+import PolicyLabPage from "./pages/PolicyLabPage";
 
 const ScrollToTop = (props: any) => {
     const location = useLocation();
@@ -37,8 +37,8 @@ export default function Main(): JSX.Element {
                 <Route path="/title1" element={<TitleIPage />} />
                 <Route path="/cropinsurance" element={<CropInsurancePage />} />
                 <Route path="/snap" element={<SNAPPage />} />
-                <Route path="/issue_whitepaper" element={<IssueWhitePaperPage />} />
-                <Route path="/policy_lab" element={<Surface51Page />} />
+                <Route path="/issue-whitepaper" element={<IssueWhitePaperPage />} />
+                <Route path="/policy-lab" element={<PolicyLabPage />} />
             </Routes>
         </ScrollToTop>
     );

--- a/src/pages/PolicyLabPage.tsx
+++ b/src/pages/PolicyLabPage.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles(() => ({
         }
     }
 }));
-export default function Surface51Page(): JSX.Element {
+export default function PolicyLabPage(): JSX.Element {
     const classes = useStyles();
     const iframeLink = "https://surface51.github.io/policy-design-lab/";
     const iframeTitle = "Surface51 Policy Design Lab";
@@ -192,20 +192,6 @@ export default function Surface51Page(): JSX.Element {
                             </a>{" "}
                             By Aleksi Knepp
                         </Typography>
-                    </Grid>
-                    <Grid
-                        item
-                        xs={12}
-                        sx={{
-                            borderTop: "1px solid #0000001F",
-                            textAlign: "center",
-                            color: "#00000080",
-                            fontSize: "0.75rem",
-                            textTransform: "uppercase",
-                            mb: 3
-                        }}
-                    >
-                        Copyright
                     </Grid>
                 </Grid>
             </Box>


### PR DESCRIPTION
Combine #263 and #266 into this PR since both of them are very small updates. These two features were supposed to be released with the new white paper, but since we are holding onto it, they will come with the top-line number update release (0.18.0).

### How to Test

1. Run the app locally (the dev instance for the landing page update is currently active).
2. Click the 'Policy Lab' option in the nav bar; you should see the URL is policy-lab instead of policy_lab.
3. Navigate to the bottom of the Policy Lab page; you should see that the Copyright section has been removed.
4. Click the 'Issues & White Papers' option in the nav bar; you should see the URL is issue-whitepaper instead of issue_whitepaper'