### PR TITLE
#278: create distinct link for each issue paper url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+- Added anchors to issues/white papers items for them to have a distinct url [#278](https://github.com/policy-design-lab/pdl-frontend/issues/278)
+
 ## [0.18.0] - 2024-05-07
 
 ### Added

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -19,7 +19,7 @@ const drawerWidth = 240;
 const navItems = [
     { title: "HOME", link: "/" },
     { title: "POLICY LAB".toUpperCase(), link: "/policy-lab" },
-    { title: "ISSUES & WHITE PAPERS", link: "/issue-whitepaper" },
+    { title: "ISSUES & WHITE PAPERS", link: "/issues-whitepapers" },
     { title: "ABOUT PDL" }
 ];
 export default function NavBar({

--- a/src/components/issueWhitePaper/cardIframe.tsx
+++ b/src/components/issueWhitePaper/cardIframe.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import DownloadIcon from "@mui/icons-material/Download";
 
 export default function CardIFrame({
+    id,
     title,
     author,
     date,
@@ -23,7 +24,7 @@ export default function CardIFrame({
     const classes = useStyles();
 
     return (
-        <Grid container className="paperCard" sx={{ display: "flex", justifyContent: "space-between" }}>
+        <Grid id={id} container className="paperCard" sx={{ display: "flex", justifyContent: "space-between" }}>
             <Grid container xs={12} sm={12}>
                 <Grid className="inCardContainer mainItems" container xs={12} sm={12}>
                     <Grid

--- a/src/components/issueWhitePaper/cardPaper.tsx
+++ b/src/components/issueWhitePaper/cardPaper.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from "@mui/styles";
 import * as React from "react";
 import DownloadIcon from "@mui/icons-material/Download";
 
-export default function CardPaper({ title, description, author, date, link }): JSX.Element {
+export default function CardPaper({ id, title, description, author, date, link }): JSX.Element {
     const useStyles = makeStyles(() => ({
         downloadButton: {
             "&:hover": {
@@ -21,6 +21,7 @@ export default function CardPaper({ title, description, author, date, link }): J
             <Grid container xs={12} sm={12}>
                 <Grid className="inCardContainer mainItems" container xs={12} sm={12}>
                     <Grid
+                        id={id}
                         container
                         xs={12}
                         sm={12}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Routes, Route, useLocation } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, useLocation } from "react-router-dom";
 import LandingPage from "./pages/LandingPage";
 import EQIPPage from "./pages/EQIPPage";
 import CSPPage from "./pages/CSPPage";
@@ -37,7 +37,8 @@ export default function Main(): JSX.Element {
                 <Route path="/title1" element={<TitleIPage />} />
                 <Route path="/cropinsurance" element={<CropInsurancePage />} />
                 <Route path="/snap" element={<SNAPPage />} />
-                <Route path="/issue-whitepaper" element={<IssueWhitePaperPage />} />
+                <Route path="/issues-whitepapers" element={<IssueWhitePaperPage />} />
+                <Route path="/issues-whitepapers/:id" element={<IssueWhitePaperPage />} />
                 <Route path="/policy-lab" element={<Surface51Page />} />
             </Routes>
         </ScrollToTop>

--- a/src/pages/IssueWhitePaperPage.tsx
+++ b/src/pages/IssueWhitePaperPage.tsx
@@ -9,6 +9,7 @@ import CardPaper from "../components/issueWhitePaper/cardPaper";
 import KnowTheScore from "../files/issues/Know_the_Score.pdf";
 
 export default function IssueWhitePaperPage(): JSX.Element {
+    const [cardId, setCardId] = React.useState("");
     const [tab, setTab] = React.useState(0);
 
     const defaultTheme = createTheme({
@@ -22,6 +23,31 @@ export default function IssueWhitePaperPage(): JSX.Element {
     const iframeWidth = window.innerWidth * 0.9;
     const iframeHeight = window.innerWidth > 1679 ? window.innerHeight * 0.92 : window.innerHeight * 0.95;
 
+    React.useEffect(() => {
+        if (window.location.hash) {
+            const hashId = window.location.hash.substring(1);
+            setCardId(hashId);
+        }
+    }, []);
+    React.useEffect(() => {
+        if (cardId) {
+            if (cardId.includes("paper")) setTab(1);
+            else setTab(0);
+            const element = document.getElementById(cardId);
+            if (element) {
+                let offsetPosition = 0;
+                if (cardId.includes("paper")) {
+                    const offset = 20;
+                    const elementPosition = element.getBoundingClientRect().top;
+                    offsetPosition = elementPosition - offset;
+                }
+                window.scrollTo({
+                    top: offsetPosition,
+                    behavior: "smooth"
+                });
+            }
+        }
+    }, [cardId]);
     return (
         <ThemeProvider theme={defaultTheme}>
             <Box sx={{ width: "100%" }}>
@@ -119,6 +145,7 @@ export default function IssueWhitePaperPage(): JSX.Element {
                                             sx={{ display: "flex", width: "100%" }}
                                         >
                                             <CardIFrame
+                                                id="issue-what-farmers-stand"
                                                 title="ISSUE BRIEF: What Farmers Stand to Lose in the Farm Bill If Congress Eliminates Conservation Investments"
                                                 iframeTitle="What Farmers Stand to Lose in the Farm Bill If Congress Eliminates Conservation Investments"
                                                 author="Professor Jonathan Coppess, Policy Design Lab, University of Illinois"
@@ -148,6 +175,7 @@ export default function IssueWhitePaperPage(): JSX.Element {
                                             sx={{ display: "flex", width: "100%" }}
                                         >
                                             <CardPaper
+                                                id="paper-know-the-score"
                                                 title="Know the Score: The Hidden Costs of Repurposing Farm Conservation Investments"
                                                 description="In the pending farm bill reauthorization, potential efforts to repurpose recent investments in farm conservation programs are plagued by hidden costs from obscure budget rules that risk farmers losing much, if not all, of the investments; this white paper discusses those hidden costs and the risks to conservation assistance to farmers."
                                                 author="Professor Jonathan Coppess, Policy Design Lab, University of Illinois"

--- a/src/pages/IssueWhitePaperPage.tsx
+++ b/src/pages/IssueWhitePaperPage.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Box, createTheme, ThemeProvider, Typography, Grid, Tabs, Tab } from "@mui/material";
+import { useParams } from "react-router-dom";
 import NavBar from "../components/NavBar";
 import "../styles/issueWhitePaper.css";
 import Footer from "../components/Footer";
@@ -9,7 +10,8 @@ import CardPaper from "../components/issueWhitePaper/cardPaper";
 import KnowTheScore from "../files/issues/Know_the_Score.pdf";
 
 export default function IssueWhitePaperPage(): JSX.Element {
-    const [cardId, setCardId] = React.useState("");
+    const { id } = useParams();
+    const [cardId, setCardId] = React.useState<string>("");
     const [tab, setTab] = React.useState(0);
 
     const defaultTheme = createTheme({
@@ -24,20 +26,19 @@ export default function IssueWhitePaperPage(): JSX.Element {
     const iframeHeight = window.innerWidth > 1679 ? window.innerHeight * 0.92 : window.innerHeight * 0.95;
 
     React.useEffect(() => {
-        if (window.location.hash) {
-            const hashId = window.location.hash.substring(1);
-            setCardId(hashId);
+        if (id) {
+            setCardId(id);
         }
-    }, []);
+    }, [id]);
     React.useEffect(() => {
         if (cardId) {
-            if (cardId.includes("paper")) setTab(1);
+            if (cardId.includes("white-paper")) setTab(1);
             else setTab(0);
             const element = document.getElementById(cardId);
             if (element) {
                 let offsetPosition = 0;
-                if (cardId.includes("paper")) {
-                    const offset = 20;
+                if (cardId.includes("white-paper")) {
+                    const offset = 20; // offset for white paper because of the iframe on the issue part
                     const elementPosition = element.getBoundingClientRect().top;
                     offsetPosition = elementPosition - offset;
                 }
@@ -175,7 +176,7 @@ export default function IssueWhitePaperPage(): JSX.Element {
                                             sx={{ display: "flex", width: "100%" }}
                                         >
                                             <CardPaper
-                                                id="paper-know-the-score"
+                                                id="white-paper-know-the-score"
                                                 title="Know the Score: The Hidden Costs of Repurposing Farm Conservation Investments"
                                                 description="In the pending farm bill reauthorization, potential efforts to repurpose recent investments in farm conservation programs are plagued by hidden costs from obscure budget rules that risk farmers losing much, if not all, of the investments; this white paper discusses those hidden costs and the risks to conservation assistance to farmers."
                                                 author="Professor Jonathan Coppess, Policy Design Lab, University of Illinois"


### PR DESCRIPTION
This PR is for #278, the only feature for the 0.19.0 front-end release, as the client requested.

### How to Test

1. When you put https://policydesignlab-dev.ncsa.illinois.edu/issues-whitepapers/white-paper-know-the-score or https://policydesignlab-dev.ncsa.illinois.edu/issues-whitepapers/issue-what-farmers-stand into your browser, you should be directly taken to the specific issue or white paper item.

2. The general issues/white papers page link has been updated to https://policydesignlab-dev.ncsa.illinois.edu/issues-whitepapers, and it is referenced by the 'ISSUES & WHITE PAPERS' option in the navbar.