### PR TITLE
Release 1.0.1: Percentage map, list switch feature and NaN error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+- Added the percentage display into the EQIP IRA map tips [#285](https://github.com/policy-design-lab/pdl-frontend/issues/285) 
+
+### Changed
+- Update the practice list to reflect current and predicted practices for EQIP IRA[#286](https://github.com/policy-design-lab/pdl-frontend/issues/286) 
+
+### Fixed
+- Fixed the NaN values in percentage table in the EQIP IRA page [#290](https://github.com/policy-design-lab/pdl-frontend/issues/290) 
+
 ## [1.0.0] - 2024-07-03
 
 ### Added

--- a/src/components/ira/IRADollarMap.tsx
+++ b/src/components/ira/IRADollarMap.tsx
@@ -34,7 +34,8 @@ const MapChart = ({
     statePerformance,
     stateCodes,
     allStates,
-    colorScale
+    colorScale,
+    summary
 }) => {
     const classes = useStyles();
     const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
@@ -72,6 +73,20 @@ const MapChart = ({
                                                 }
                                             });
                                         }
+                                        // calculate the total of all practices and get the percentage of the practices
+                                        const totalNationwidePayment = practices.includes("Total")
+                                            ? summary[year].totalPaymentInDollars
+                                            : summary[year].practices
+                                                  .filter((p) => practices.includes(p.practiceName))
+                                                  .reduce((acc, p) => acc + p.totalPaymentInDollars, 0);
+                                        let totalPaymentPercentageNationwide = (
+                                            (practicePayment / totalNationwidePayment) *
+                                            100
+                                        ).toFixed(2);
+                                        totalPaymentPercentageNationwide =
+                                            totalPaymentPercentageNationwide === "NaN"
+                                                ? "0"
+                                                : totalPaymentPercentageNationwide;
                                         const hoverContent = (
                                             <div className="map_tooltip">
                                                 <div className={classes.tooltip_header}>
@@ -80,14 +95,24 @@ const MapChart = ({
                                                 <table className={classes.tooltip_table}>
                                                     <tbody key={geo.properties.name}>
                                                         {practices.includes("Total") ? (
-                                                            <tr style={topTipStyle}>
-                                                                <td className={classes.tooltip_topcell_left}>
-                                                                    Total Benefits:
-                                                                </td>
-                                                                <td className={classes.tooltip_topcell_right}>
-                                                                    ${ShortFormat(practicePayment, undefined, 2)}
-                                                                </td>
-                                                            </tr>
+                                                            <span>
+                                                                <tr style={topTipStyle}>
+                                                                    <td className={classes.tooltip_topcell_left}>
+                                                                        Total Benefits:
+                                                                    </td>
+                                                                    <td className={classes.tooltip_topcell_right}>
+                                                                        ${ShortFormat(practicePayment, undefined, 2)}
+                                                                    </td>
+                                                                </tr>
+                                                                <tr style={topTipStyle}>
+                                                                    <td className={classes.tooltip_bottomcell_left}>
+                                                                        PCT. Nationwide:
+                                                                    </td>
+                                                                    <td className={classes.tooltip_bottomcell_right}>
+                                                                        {totalPaymentPercentageNationwide}%
+                                                                    </td>
+                                                                </tr>
+                                                            </span>
                                                         ) : (
                                                             <span>
                                                                 {practices.length > 1 &&
@@ -175,17 +200,18 @@ const MapChart = ({
                                                                         </td>
                                                                     </tr>
                                                                 )}
+                                                                <tr style={topTipStyle}>
+                                                                    <td className={classes.tooltip_bottomcell_left}>
+                                                                        {practices.length === 1
+                                                                            ? "PCT. Nationwide:"
+                                                                            : "PCT. Nationwide (All Practices):"}
+                                                                    </td>
+                                                                    <td className={classes.tooltip_bottomcell_right}>
+                                                                        {totalPaymentPercentageNationwide}%
+                                                                    </td>
+                                                                </tr>
                                                             </span>
                                                         )}
-
-                                                        {/* <tr>
-                                                        <td className={classes.tooltip_regularcell_left}>
-                                                            PCT. Nationwide:
-                                                        </td>
-                                                        <td className={classes.tooltip_regularcell_right}>
-                                                            {totalPaymentInPercentage} %
-                                                        </td>
-                                                    </tr> */}
                                                     </tbody>
                                                 </table>
                                                 {/* )} */}
@@ -393,7 +419,7 @@ MapChart.propTypes = {
     maxValue: PropTypes.number
 };
 
-const IRAMap = ({
+const IRADollarMap = ({
     subtitle,
     practices,
     predict,
@@ -401,7 +427,8 @@ const IRAMap = ({
     mapColor,
     statePerformance,
     stateCodes,
-    allStates
+    allStates,
+    summary
 }: {
     subtitle: string;
     practices: any;
@@ -411,6 +438,7 @@ const IRAMap = ({
     statePerformance: any;
     stateCodes: any;
     allStates: any;
+    summary: any;
 }): JSX.Element => {
     const [content, setContent] = useState("");
     const quantizeArray: number[] = [];
@@ -524,6 +552,7 @@ const IRAMap = ({
                 stateCodes={stateCodes}
                 allStates={allStates}
                 colorScale={colorScale}
+                summary={summary}
             />
             <div className="tooltip-container">
                 <ReactTooltip className={`${classes.customized_tooltip} tooltip`} backgroundColor={tooltipBkgColor}>
@@ -550,4 +579,4 @@ const titleElement = ({ subtitle, year }): JSX.Element => {
         </Box>
     );
 };
-export default IRAMap;
+export default IRADollarMap;

--- a/src/components/ira/IRADollarTable.tsx
+++ b/src/components/ira/IRADollarTable.tsx
@@ -90,10 +90,10 @@ function IRADollarTable({
         const newRecord = { state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === s)[0]] };
         Object.entries(hashmap[s]).forEach(([attr, value]) => {
             if (value) {
-                const formattedValue = value.toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2
-                });
+                const formattedValue = value
+                    .toLocaleString(undefined, { minimumFractionDigits: 2 })
+                    .toString()
+                    .split(".")[0];
                 if (attr.includes("Dollar")) {
                     newRecord[attr] = `$${formattedValue}`;
                 } else {

--- a/src/components/ira/IRADollarTable.tsx
+++ b/src/components/ira/IRADollarTable.tsx
@@ -90,10 +90,10 @@ function IRADollarTable({
         const newRecord = { state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === s)[0]] };
         Object.entries(hashmap[s]).forEach(([attr, value]) => {
             if (value) {
-                const formattedValue = value
-                    .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                    .toString()
-                    .split(".")[0];
+                const formattedValue = value.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2
+                });
                 if (attr.includes("Dollar")) {
                     newRecord[attr] = `$${formattedValue}`;
                 } else {

--- a/src/components/ira/IRAPercentageTable.tsx
+++ b/src/components/ira/IRAPercentageTable.tsx
@@ -165,6 +165,7 @@ function IRAPercentageTable({
             } else {
                 newRecord[attr] = "0";
             }
+            newRecord[attr] = newRecord[attr].includes("NaN") ? "0.00%" : newRecord[attr];
         });
         resultData.push(newRecord);
     });

--- a/src/components/ira/IRAPredictedDollarTable.tsx
+++ b/src/components/ira/IRAPredictedDollarTable.tsx
@@ -80,10 +80,10 @@ function IRAPredictedDollarTable({
         const newRecord = { state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === s)[0]] };
         Object.entries(hashmap[s]).forEach(([attr, value]) => {
             if (value) {
-                const formattedValue = value
-                    .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                    .toString()
-                    .split(".")[0];
+                const formattedValue = value.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2
+                });
                 if (attr.includes("Dollar")) {
                     newRecord[attr] = `$${formattedValue}`;
                 } else {
@@ -95,7 +95,6 @@ function IRAPredictedDollarTable({
         });
         resultData.push(newRecord);
     });
-
     const columnPrep = [];
     columnPrep.push({ Header: "STATE", accessor: "state", sortType: compareWithAlphabetic });
     const attrs = resultData[0] ? Object.keys(resultData[0]).filter((item) => item.toLowerCase() !== "state") : [];

--- a/src/components/ira/IRAPredictedDollarTable.tsx
+++ b/src/components/ira/IRAPredictedDollarTable.tsx
@@ -80,10 +80,10 @@ function IRAPredictedDollarTable({
         const newRecord = { state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === s)[0]] };
         Object.entries(hashmap[s]).forEach(([attr, value]) => {
             if (value) {
-                const formattedValue = value.toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2
-                });
+                const formattedValue = value
+                    .toLocaleString(undefined, { minimumFractionDigits: 2 })
+                    .toString()
+                    .split(".")[0];
                 if (attr.includes("Dollar")) {
                     newRecord[attr] = `$${formattedValue}`;
                 } else {

--- a/src/components/ira/IRAPredictedMap.tsx
+++ b/src/components/ira/IRAPredictedMap.tsx
@@ -36,7 +36,8 @@ const MapChart = ({
     predictedPerformance,
     stateCodes,
     allStates,
-    colorScale
+    colorScale,
+    summary
 }) => {
     const classes = useStyles();
     return (
@@ -69,6 +70,17 @@ const MapChart = ({
                                         }
                                     });
                                 }
+                                const totalNationwidePayment = practices.includes("Total")
+                                    ? summary[year].predictedTotalPaymentInDollars
+                                    : summary[year].practices
+                                          .filter((p) => practices.includes(p.practiceName))
+                                          .reduce((acc, p) => acc + p.predictedTotalPaymentInDollars, 0);
+                                let totalPaymentPercentageNationwide = (
+                                    (practicePayment / totalNationwidePayment) *
+                                    100
+                                ).toFixed(2);
+                                totalPaymentPercentageNationwide =
+                                    totalPaymentPercentageNationwide === "NaN" ? "0" : totalPaymentPercentageNationwide;
                                 const hoverContent = (
                                     <div className="map_tooltip">
                                         <div className={classes.tooltip_header}>
@@ -77,14 +89,24 @@ const MapChart = ({
                                         <table className={classes.tooltip_table}>
                                             <tbody key={geo.properties.name}>
                                                 {practices.includes("Total") ? (
-                                                    <tr style={topTipStyle}>
-                                                        <td className={classes.tooltip_topcell_left}>
-                                                            Total Predicted Benefits:
-                                                        </td>
-                                                        <td className={classes.tooltip_topcell_right}>
-                                                            ${ShortFormat(practicePayment, undefined, 2)}
-                                                        </td>
-                                                    </tr>
+                                                    <span>
+                                                        <tr style={topTipStyle}>
+                                                            <td className={classes.tooltip_topcell_left}>
+                                                                Total Predicted Benefits:
+                                                            </td>
+                                                            <td className={classes.tooltip_topcell_right}>
+                                                                ${ShortFormat(practicePayment, undefined, 2)}
+                                                            </td>
+                                                        </tr>
+                                                        <tr style={topTipStyle}>
+                                                            <td className={classes.tooltip_bottomcell_left}>
+                                                                PCT. Nationwide:
+                                                            </td>
+                                                            <td className={classes.tooltip_bottomcell_right}>
+                                                                {totalPaymentPercentageNationwide}%
+                                                            </td>
+                                                        </tr>
+                                                    </span>
                                                 ) : (
                                                     <span>
                                                         {practices.length > 1 &&
@@ -164,6 +186,16 @@ const MapChart = ({
                                                                 </td>
                                                             </tr>
                                                         )}
+                                                        <tr style={topTipStyle}>
+                                                            <td className={classes.tooltip_bottomcell_left}>
+                                                                {practices.length === 1
+                                                                    ? "PCT. Nationwide:"
+                                                                    : "PCT. Nationwide (All Practices):"}
+                                                            </td>
+                                                            <td className={classes.tooltip_bottomcell_right}>
+                                                                {totalPaymentPercentageNationwide}%
+                                                            </td>
+                                                        </tr>
                                                     </span>
                                                 )}
                                             </tbody>
@@ -250,7 +282,8 @@ const IRAPredictedMap = ({
     mapColor,
     predictedPerformance,
     stateCodes,
-    allStates
+    allStates,
+    summary
 }: {
     subtitle: string;
     practices: any;
@@ -260,6 +293,7 @@ const IRAPredictedMap = ({
     predictedPerformance: any;
     stateCodes: any;
     allStates: any;
+    summary: any;
 }): JSX.Element => {
     const [content, setContent] = useState("");
     const quantizeArray: number[] = [];
@@ -339,6 +373,7 @@ const IRAPredictedMap = ({
                 stateCodes={stateCodes}
                 allStates={allStates}
                 colorScale={colorScale}
+                summary={summary}
             />
             <div className="tooltip-container">
                 <ReactTooltip className={`${classes.customized_tooltip} tooltip`} backgroundColor={tooltipBkgColor}>

--- a/src/components/ira/IRAPredictedPercentageTable.tsx
+++ b/src/components/ira/IRAPredictedPercentageTable.tsx
@@ -145,6 +145,7 @@ function IRAPredictedPercentageTable({
             } else {
                 newRecord[attr] = "0";
             }
+            newRecord[attr] = newRecord[attr].includes("NaN") ? "0.00%" : newRecord[attr];
         });
         resultData.push(newRecord);
     });

--- a/src/components/ira/IRAPredictedPercentageTable.tsx
+++ b/src/components/ira/IRAPredictedPercentageTable.tsx
@@ -85,9 +85,7 @@ function IRAPredictedPercentageTable({
             });
 
             let totalStatePayments = 0;
-            const totalStateInstances = 0;
             let totalNationalPayments = 0;
-            const totalNationalInstances = 0;
 
             practices.forEach((practice) => {
                 const statePracticeData = stateData.practices.find((p) => p.practiceName === practice);
@@ -153,7 +151,6 @@ function IRAPredictedPercentageTable({
     const columnPrep = [];
     columnPrep.push({ Header: "STATE", accessor: "state", sortType: compareWithAlphabetic });
     // filter out all data attributes with the word "percentage" in them
-
     resultData = resultData.map(
         (item) =>
             Object.keys(item)

--- a/src/components/ira/IRAPredictedPercentageTable.tsx
+++ b/src/components/ira/IRAPredictedPercentageTable.tsx
@@ -35,7 +35,7 @@ function IRAPredictedPercentageTable({
                 hashmap[state][attribute] = attributeData;
                 // Calculate percentage nationwide
                 if (attribute === "predictedTotalPaymentInDollars") {
-                    hashmap[state][`${attribute}PercentageNationwide`] = `${(
+                    hashmap[state][`${attribute}PredictedPercentageNationwide`] = `${(
                         (attributeData / summary[year].predictedTotalPaymentInDollars) *
                         100
                     ).toFixed(2)}%`;
@@ -60,7 +60,7 @@ function IRAPredictedPercentageTable({
                         hashmap[state][new_key] = 0;
                         practices_total[state][attribute] += 0;
                         // Set percentage to 0 for missing practices
-                        hashmap[state][`${new_key}PercentageNationwide`] = "0.00%";
+                        hashmap[state][`${new_key}PredictedPercentageNationwide`] = "0.00%";
                     });
                 } else {
                     const attributeData = practiceData[0];
@@ -75,7 +75,7 @@ function IRAPredictedPercentageTable({
                                     ? nationalPracticeData.predictedTotalPaymentInDollars
                                     : nationalPracticeData.totalPracticeInstanceCount;
 
-                            hashmap[state][`${new_key}PercentageNationwide`] = `${(
+                            hashmap[state][`${new_key}PredictedPercentageNationwide`] = `${(
                                 (attributeData[attribute] / nationalTotal) *
                                 100
                             ).toFixed(2)}%`;
@@ -108,13 +108,13 @@ function IRAPredictedPercentageTable({
                 if (!practices_total[state] || practices_total[state][attribute] === undefined) {
                     if (!hashmap[state]) hashmap[state] = {};
                     hashmap[state][`All Practices: ${attribute}`] = 0;
-                    hashmap[state][`All Practices: ${attribute}PercentageNationwide`] = "0.00%";
+                    hashmap[state][`All Practices: ${attribute}PredictedPercentageNationwide`] = "0.00%";
                 } else {
                     hashmap[state][`All Practices: ${attribute}`] = practices_total[state][attribute];
 
                     // Calculate percentage for all practices combined
                     if (attribute === "predictedTotalPaymentInDollars") {
-                        hashmap[state][`All Practices: ${attribute}PercentageNationwide`] = `${(
+                        hashmap[state][`All Practices: ${attribute}PredictedPercentageNationwide`] = `${(
                             (totalStatePayments / totalNationalPayments) *
                             100
                         ).toFixed(2)}%`;
@@ -128,14 +128,14 @@ function IRAPredictedPercentageTable({
         Object.entries(hashmap[s]).forEach(([attr, value]) => {
             if (value) {
                 if (attr.includes("Dollar")) {
-                    if (attr.includes("PercentageNationwide")) {
+                    if (attr.includes("PredictedPercentageNationwide")) {
                         newRecord[attr] = value; // Keep as percentage
                     } else {
                         newRecord[attr] = `$${parseFloat(value).toLocaleString(undefined, {
                             minimumFractionDigits: 2
                         })}`;
                     }
-                } else if (attr.includes("PercentageNationwide")) {
+                } else if (attr.includes("PredictedPercentageNationwide")) {
                     newRecord[attr] = value; // Keep as percentage
                 } else {
                     newRecord[attr] = parseFloat(value).toLocaleString(undefined, { minimumFractionDigits: 2 });

--- a/src/components/ira/TabPanel.tsx
+++ b/src/components/ira/TabPanel.tsx
@@ -164,18 +164,20 @@ function TabPanel({
         if (years.length) {
             setSelectedYear(minYear);
         }
-        const currentPractices = isPredictionOn
-            ? practiceNames[predictedYear].sort((a, b) => a.localeCompare(b))
-            : practiceNames[minYear].sort((a, b) => a.localeCompare(b));
-        setPractices(["Total", ...currentPractices]);
-        if (selectedPractices.length === 0) {
-            setSelectedPractices(["Total"]);
+        if (Object.keys(practiceNames).length > 0) {
+            const currentPractices = isPredictionOn
+                ? practiceNames[predictedYear].sort((a, b) => a.localeCompare(b))
+                : practiceNames[minYear].sort((a, b) => a.localeCompare(b));
+            setPractices(["Total", ...currentPractices]);
+            if (selectedPractices.length === 0) {
+                setSelectedPractices(["Total"]);
+            }
         }
     }, [minYear, selectedYear, selectedPractices, practiceNames]);
     React.useEffect(() => {
         updateData();
+        updatePredictedData();
     }, [selectedPractices, selectedYear, isPredictionOn]);
-
     return (
         <Box role="tabpanel" hidden={v !== index}>
             {v === index && (
@@ -210,17 +212,19 @@ function TabPanel({
                                                         position: "relative"
                                                     }}
                                                 >
-                                                    <IRAPredictedMap
-                                                        subtitle={title}
-                                                        year={predictedYear}
-                                                        predictedPerformance={updatedPredictedData}
-                                                        practices={selectedPractices}
-                                                        stateCodes={stateCodes}
-                                                        allStates={allStates}
-                                                        mapColor={mapColor}
-                                                        predict={selectedPredict}
-                                                        summary={summaryData}
-                                                    />
+                                                    {Object.keys(updatedPredictedData).length > 0 && (
+                                                        <IRAPredictedMap
+                                                            subtitle={title}
+                                                            year={predictedYear}
+                                                            predictedPerformance={updatedPredictedData}
+                                                            practices={selectedPractices}
+                                                            stateCodes={stateCodes}
+                                                            allStates={allStates}
+                                                            mapColor={mapColor}
+                                                            predict={selectedPredict}
+                                                            summary={summaryData}
+                                                        />
+                                                    )}
                                                 </Grid>
                                             )}
                                         </Box>
@@ -448,18 +452,20 @@ function TabPanel({
                                 className="offset-sm-1"
                                 sx={{ display: tab !== 0 ? "none" : "div" }}
                             >
-                                <IRAPredictedDollarTable
-                                    key={`${selectedPractices.join(",")}-${selectedYear}-${isPredictionOn}`}
-                                    tableTitle={`${title} IRA Predicted Data ($) By States in ${predictedYear}`}
-                                    year={predictedYear}
-                                    IRAPredictedData={updatedPredictedData}
-                                    skipColumns={[]}
-                                    stateCodes={stateCodes}
-                                    practices={selectedPractices}
-                                    predict={selectedPredict}
-                                    colors={[]}
-                                    attributes={["predictedTotalPaymentInDollars"]}
-                                />
+                                {Object.keys(updatedPredictedData).length > 0 && (
+                                    <IRAPredictedDollarTable
+                                        key={`${selectedPractices.join(",")}-${selectedYear}-${isPredictionOn}`}
+                                        tableTitle={`${title} IRA Predicted Data ($) By States in ${predictedYear}`}
+                                        year={predictedYear}
+                                        IRAPredictedData={updatedPredictedData}
+                                        skipColumns={[]}
+                                        stateCodes={stateCodes}
+                                        practices={selectedPractices}
+                                        predict={selectedPredict}
+                                        colors={[]}
+                                        attributes={["predictedTotalPaymentInDollars"]}
+                                    />
+                                )}
                             </Grid>
                             <Grid
                                 item
@@ -468,19 +474,21 @@ function TabPanel({
                                 className="offset-sm-1"
                                 sx={{ display: tab !== 1 ? "none" : "div" }}
                             >
-                                <IRAPredictedPercentageTable
-                                    key={`${selectedPractices.join(",")}-${selectedYear}-${isPredictionOn}`}
-                                    tableTitle={`${title} IRA Predicted Data (%) By States in ${selectedYear}`}
-                                    year={predictedYear}
-                                    IRAPredictedData={updatedPredictedData}
-                                    summary={summaryData}
-                                    skipColumns={[]}
-                                    stateCodes={stateCodes}
-                                    practices={selectedPractices}
-                                    predict={selectedPredict}
-                                    colors={[]}
-                                    attributes={["predictedTotalPaymentInDollars"]}
-                                />
+                                {Object.keys(updatedPredictedData).length > 0 && (
+                                    <IRAPredictedPercentageTable
+                                        key={`${selectedPractices.join(",")}-${selectedYear}-${isPredictionOn}`}
+                                        tableTitle={`${title} IRA Predicted Data (%) By States in ${selectedYear}`}
+                                        year={predictedYear}
+                                        IRAPredictedData={updatedPredictedData}
+                                        summary={summaryData}
+                                        skipColumns={[]}
+                                        stateCodes={stateCodes}
+                                        practices={selectedPractices}
+                                        predict={selectedPredict}
+                                        colors={[]}
+                                        attributes={["predictedTotalPaymentInDollars"]}
+                                    />
+                                )}
                             </Grid>
                         </Grid>
                     )}

--- a/src/components/ira/TabPanel.tsx
+++ b/src/components/ira/TabPanel.tsx
@@ -26,6 +26,8 @@ import IRAPercentageTable from "./IRAPercentageTable";
 import IRAPredictedMap from "./IRAPredictedMap";
 import IRAPredictedDollarTable from "./IRAPredictedDollarTable";
 import IRAPredictedPercentageTable from "./IRAPredictedPercentageTable";
+import { parse } from "../../../../../../BC/fabric-samples/asset-transfer-secured-agreement/application-gateway-typescript/src/utils";
+import ParagraphCard from "../../../../../HEROP/place-discovery/src/components/search/detailPanel/paragraphCard/paragraphCard";
 
 function TabPanel({
     v,
@@ -55,11 +57,11 @@ function TabPanel({
     const years = stateDistributionData ? Object.keys(stateDistributionData).map(Number) : [];
     const [updatedData, setUpdatedData] = useState(stateDistributionData);
     const [updatedPredictedData, setUpdatedPredictedData] = useState(predictedData);
-    const minYear = Math.min(...years);
+    const minYear = Math.min(...years).toString();
     const maxYear = Math.max(...years);
     const [isPlaying, setIsPlaying] = useState(false);
     const [intervalId, setIntervalId] = useState<ReturnType<typeof setInterval> | null>(null);
-    const [selectedYear, setSelectedYear] = useState(minYear);
+    const [selectedYear, setSelectedYear] = useState(minYear.toString());
     const [selectedPredict, setSelectedPredict] = useState("Min");
     const [selectedPractices, setSelectedPractices] = useState<string[]>([]);
     const [practices, setPractices] = useState<string[]>([]);
@@ -84,11 +86,12 @@ function TabPanel({
         }
     };
     const handleSwitchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setIsPredictionOn(event.target.checked);
-        const currentPractices: string[] = practiceNames[event.target.checked ? predictedYear : minYear]
-            .slice()
-            .sort((a, b) => a.localeCompare(b));
-        const newPractices: string[] = ["Total", ...currentPractices];
+        const isOn = event.target.checked;
+        setIsPredictionOn(isOn);
+        const year = isOn ? predictedYear : minYear;
+        setSelectedYear(year);
+        const currentPractices = practiceNames[year].slice().sort((a, b) => a.localeCompare(b));
+        const newPractices = ["Total", ...currentPractices];
         setPractices(newPractices);
         const overlapped_practices: string[] = newPractices.filter((element) => selectedPractices.includes(element));
         setSelectedPractices(overlapped_practices.length === 0 ? ["Total"] : overlapped_practices);
@@ -163,12 +166,14 @@ function TabPanel({
         if (years.length) {
             setSelectedYear(minYear);
         }
-        const currentPractices = practiceNames[selectedYear].sort((a, b) => a.localeCompare(b)); // sort the practice list from a to z
+        const currentPractices = isPredictionOn
+            ? practiceNames[predictedYear].sort((a, b) => a.localeCompare(b))
+            : practiceNames[minYear].sort((a, b) => a.localeCompare(b));
         setPractices(["Total", ...currentPractices]);
         if (selectedPractices.length === 0) {
             setSelectedPractices(["Total"]);
         }
-    }, [minYear, selectedPractices]);
+    }, [minYear, selectedYear, selectedPractices, practiceNames]);
     React.useEffect(() => {
         updateData();
     }, [selectedPractices, selectedYear, isPredictionOn]);

--- a/src/components/ira/TabPanel.tsx
+++ b/src/components/ira/TabPanel.tsx
@@ -26,8 +26,6 @@ import IRAPercentageTable from "./IRAPercentageTable";
 import IRAPredictedMap from "./IRAPredictedMap";
 import IRAPredictedDollarTable from "./IRAPredictedDollarTable";
 import IRAPredictedPercentageTable from "./IRAPredictedPercentageTable";
-import { parse } from "../../../../../../BC/fabric-samples/asset-transfer-secured-agreement/application-gateway-typescript/src/utils";
-import ParagraphCard from "../../../../../HEROP/place-discovery/src/components/search/detailPanel/paragraphCard/paragraphCard";
 
 function TabPanel({
     v,

--- a/src/components/ira/TabPanel.tsx
+++ b/src/components/ira/TabPanel.tsx
@@ -20,7 +20,7 @@ import { styled } from "@mui/system";
 import { CurrencyDollar, Percent } from "react-bootstrap-icons";
 
 import useWindowSize from "../shared/WindowSizeHook";
-import IRAMap from "./IRAMap";
+import IRADollarMap from "./IRADollarMap";
 import IRADollarTable from "./IRADollarTable";
 import IRAPercentageTable from "./IRAPercentageTable";
 import IRAPredictedMap from "./IRAPredictedMap";
@@ -61,7 +61,8 @@ function TabPanel({
     const [intervalId, setIntervalId] = useState<ReturnType<typeof setInterval> | null>(null);
     const [selectedYear, setSelectedYear] = useState(minYear);
     const [selectedPredict, setSelectedPredict] = useState("Min");
-    const [selectedPractices, setSelectedPractices] = useState([]);
+    const [selectedPractices, setSelectedPractices] = useState<string[]>([]);
+    const [practices, setPractices] = useState<string[]>([]);
     const mapColor = ["#F0F9E8", "#BAE4BC", "#7BCCC4", "#43A2CA", "#0868AC"]; // title II color
     const the = useTheme();
     const isSmallScreen = useMediaQuery(the.breakpoints.down("sm"));
@@ -82,8 +83,15 @@ function TabPanel({
             setTab(newTab);
         }
     };
-    const handleSwitchChange = (event) => {
+    const handleSwitchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         setIsPredictionOn(event.target.checked);
+        const currentPractices: string[] = practiceNames[event.target.checked ? predictedYear : minYear]
+            .slice()
+            .sort((a, b) => a.localeCompare(b));
+        const newPractices: string[] = ["Total", ...currentPractices];
+        setPractices(newPractices);
+        const overlapped_practices: string[] = newPractices.filter((element) => selectedPractices.includes(element));
+        setSelectedPractices(overlapped_practices.length === 0 ? ["Total"] : overlapped_practices);
     };
 
     const handleYearChange = (event) => {
@@ -93,8 +101,6 @@ function TabPanel({
         value: year,
         label: year.toString()
     }));
-    const currentPractices = practiceNames[selectedYear].sort((a, b) => a.localeCompare(b)); // sort the practice list from a to z
-    const practices: any[] = ["Total", ...currentPractices];
     const handlePracticeChange = (event) => {
         const {
             target: { value }
@@ -157,6 +163,8 @@ function TabPanel({
         if (years.length) {
             setSelectedYear(minYear);
         }
+        const currentPractices = practiceNames[selectedYear].sort((a, b) => a.localeCompare(b)); // sort the practice list from a to z
+        setPractices(["Total", ...currentPractices]);
         if (selectedPractices.length === 0) {
             setSelectedPractices(["Total"]);
         }
@@ -208,6 +216,7 @@ function TabPanel({
                                                         allStates={allStates}
                                                         mapColor={mapColor}
                                                         predict={selectedPredict}
+                                                        summary={summaryData}
                                                     />
                                                 </Grid>
                                             )}
@@ -249,7 +258,7 @@ function TabPanel({
                                                         position: "relative"
                                                     }}
                                                 >
-                                                    <IRAMap
+                                                    <IRADollarMap
                                                         subtitle={title}
                                                         year={selectedYear.toString()}
                                                         statePerformance={updatedData}
@@ -258,6 +267,7 @@ function TabPanel({
                                                         allStates={allStates}
                                                         mapColor={mapColor}
                                                         predict={selectedPredict}
+                                                        summary={summaryData}
                                                     />
                                                 </Grid>
                                             )}


### PR DESCRIPTION
This PR covers issues #285, #286, and #290. It includes the following features: adding percentage numbers to the map tips, switching the practice list when users switch between present and predicted data, and fixing the NaN display for some percentage calculations.

## How to Test

1. Navigate to the IRA page and hover over the map. You should see 'PCT. Nationwide' displayed, which should match the Percentage table under the map:

<img width="983" alt="Screenshot 2024-07-18 at 5 20 12 PM" src="https://github.com/user-attachments/assets/131c625a-00a4-4476-88c6-de412c263902">


2. Select a few practices, including some that are not available for predicted years (such as Forest Management Practice Design). You should see a total percentage calculation for all practices appear in the map tips, also matching the Percentage table under the map:

<img width="718" alt="Screenshot 2024-07-18 at 5 23 06 PM" src="https://github.com/user-attachments/assets/b6c4c0a9-86ea-4767-86d4-8ae68ef5621d">


3. Turn on the '2024-2031 Prediction' switch. You should see any practices that are not available in predicted years (such as Forest Management Practice Design) disappear from the map. The map and tables will update to reflect these changes.

4. Repeat steps 1 and 2 for the predicted data. No NaN value should appear in any tables or maps.

5. Turn the '2024-2031 Prediction' switch off and ONLY select practices that are not available in predicted years. Then turn the switch on, and you should see 'Total' being automatically selected in the practice list because all other practices have been removed.