### PR TITLE
Prevent pages to render before all data got loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+- Updated all pages to prevent components from rendering before all data is ready [#294](https://github.com/policy-design-lab/pdl-frontend/issues/294) 
+
+### Fixed
+- Fixed the occasional bug where the IRA page failed to load because the summary data was not ready [#293](https://github.com/policy-design-lab/pdl-frontend/issues/293) 
+
 ## [1.0.1] - 2024-07-19
 
 ### Added

--- a/src/pages/CRPPage.tsx
+++ b/src/pages/CRPPage.tsx
@@ -16,7 +16,7 @@ export default function CRPPage(): JSX.Element {
     const year = "2018-2022";
     const attribute = "totalPaymentInDollars";
     const [checked, setChecked] = React.useState(0);
-
+    const [isDataReady, setIsDataReady] = React.useState(false);
     const [stateDistributionData, setStateDistributionData] = React.useState({});
     const [stateCodesData, setStateCodesData] = React.useState({});
     const [stateCodesArray, setStateCodesArray] = React.useState({});
@@ -38,29 +38,27 @@ export default function CRPPage(): JSX.Element {
     let grasslandPyamentInDollars = 0;
 
     React.useEffect(() => {
-        const allstates_url = `${config.apiUrl}/states`;
-        getJsonDataFromUrl(allstates_url).then((response) => {
-            setAllStatesData(response);
-        });
-
-        const statecode_url = `${config.apiUrl}/statecodes`;
-        getJsonDataFromUrl(statecode_url).then((response) => {
-            setStateCodesArray(response);
-            const converted_json = convertAllState(response);
-            setStateCodesData(converted_json);
-        });
-
-        const statedistribution_url = `${config.apiUrl}/titles/title-ii/programs/crp/state-distribution`;
-        getJsonDataFromUrl(statedistribution_url).then((response) => {
-            setStateDistributionData(response);
-        });
-
-        const chartData_url = `${config.apiUrl}/titles/title-ii/programs/crp/summary`;
-        getJsonDataFromUrl(chartData_url).then((response) => {
-            processData(response);
-        });
+        const fetchData = async () => {
+            try {
+                const [allStatesResponse, stateCodesResponse, stateDistributionResponse, chartDataResponse] =
+                    await Promise.all([
+                        getJsonDataFromUrl(`${config.apiUrl}/states`),
+                        getJsonDataFromUrl(`${config.apiUrl}/statecodes`),
+                        getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/crp/state-distribution`),
+                        getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/crp/summary`)
+                    ]);
+                setAllStatesData(allStatesResponse);
+                setStateCodesArray(stateCodesResponse);
+                setStateCodesData(convertAllState(stateCodesResponse));
+                setStateDistributionData(stateDistributionResponse);
+                processData(chartDataResponse);
+                setIsDataReady(true);
+            } catch (error) {
+                console.error("Error fetching data:", error);
+            }
+        };
+        fetchData();
     }, []);
-
     const processData = (chartData) => {
         if (chartData.programs === undefined) return;
 
@@ -120,10 +118,7 @@ export default function CRPPage(): JSX.Element {
 
     return (
         <ThemeProvider theme={defaultTheme}>
-            {Object.keys(stateCodesData).length > 0 &&
-            Object.keys(allStatesData).length > 0 &&
-            Object.keys(stateDistributionData).length > 0 &&
-            zeroCategories.length > 0 ? (
+            {isDataReady ? (
                 <Box sx={{ width: "100%" }}>
                     <Box sx={{ position: "fixed", zIndex: 1400, width: "100%" }}>
                         <NavBar bkColor="rgba(255, 255, 255, 1)" ftColor="rgba(47, 113, 100, 1)" logo="light" />

--- a/src/pages/CSPPage.tsx
+++ b/src/pages/CSPPage.tsx
@@ -24,6 +24,7 @@ export default function CSPPage(): JSX.Element {
     const [firstTotal, setFirstTotal] = React.useState(0);
     const [secondTotal, setSecondTotal] = React.useState(0);
     const [zeroCategories, setZeroCategories] = React.useState([]);
+    const [isDataReady, setIsDataReady] = React.useState(false);
 
     const defaultTheme = createTheme();
     let landManagementTotal = 0;
@@ -46,32 +47,27 @@ export default function CSPPage(): JSX.Element {
     const zeroCategory = [];
 
     const csp_year = "2018-2022";
-
     React.useEffect(() => {
-        const state_perf_url = `${config.apiUrl}/titles/title-ii/programs/csp/state-distribution`;
-        getJsonDataFromUrl(state_perf_url).then((response) => {
-            const converted_perf_json = response;
-            setStatePerformance(converted_perf_json);
-        });
-
-        const allstates_url = `${config.apiUrl}/states`;
-        getJsonDataFromUrl(allstates_url).then((response) => {
-            const converted_json = response;
-            setAllStates(converted_json);
-        });
-
-        const statecode_url = `${config.apiUrl}/statecodes`;
-        getJsonDataFromUrl(statecode_url).then((response) => {
-            setStateCodesArray(response);
-            const converted_json = convertAllState(response);
-            setStateCodesData(converted_json);
-        });
-
-        const chartdata_url = `${config.apiUrl}/titles/title-ii/programs/csp/summary`;
-        getJsonDataFromUrl(chartdata_url).then((response) => {
-            const converted_chart_json = response;
-            processData(converted_chart_json);
-        });
+        const fetchData = async () => {
+            try {
+                const [statePerformanceResponse, allStatesResponse, stateCodesResponse, summaryResponse] =
+                    await Promise.all([
+                        getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/csp/state-distribution`),
+                        getJsonDataFromUrl(`${config.apiUrl}/states`),
+                        getJsonDataFromUrl(`${config.apiUrl}/statecodes`),
+                        getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/csp/summary`)
+                    ]);
+                setStatePerformance(statePerformanceResponse);
+                setAllStates(allStatesResponse);
+                setStateCodesArray(stateCodesResponse);
+                setStateCodesData(convertAllState(stateCodesResponse));
+                processData(summaryResponse);
+                setIsDataReady(true);
+            } catch (error) {
+                console.error("Error fetching data:", error);
+            }
+        };
+        fetchData();
     }, []);
 
     const processData = (chartData) => {
@@ -191,10 +187,7 @@ export default function CSPPage(): JSX.Element {
     };
     return (
         <ThemeProvider theme={defaultTheme}>
-            {allStates.length > 0 &&
-            statePerformance[csp_year] !== undefined &&
-            zeroCategories.length > 0 &&
-            stateCodesArray.length > 0 ? (
+            {isDataReady ? (
                 <Box sx={{ width: "100%" }}>
                     <Box sx={{ position: "fixed", zIndex: 1400, width: "100%" }}>
                         <NavBar bkColor="rgba(255, 255, 255, 1)" ftColor="rgba(47, 113, 100, 1)" logo="light" />

--- a/src/pages/CropInsurancePage.tsx
+++ b/src/pages/CropInsurancePage.tsx
@@ -33,21 +33,25 @@ export default function CropInsurancePage(): JSX.Element {
     const cropInsuranceDiv = React.useRef(null);
     const [checked, setChecked] = React.useState("0");
     const mapColor = ["#C26C06", "#CCECE6", "#66C2A4", "#238B45", "#005C24"];
+    const [isDataReady, setIsDataReady] = React.useState(false);
 
     React.useEffect(() => {
-        const allstates_url = `${config.apiUrl}/states`;
-        getJsonDataFromUrl(allstates_url).then((response) => {
-            setAllStatesData(response);
-        });
-        const statecode_url = `${config.apiUrl}/statecodes`;
-        getJsonDataFromUrl(statecode_url).then((response) => {
-            const converted_json = convertAllState(response);
-            setStateCodesData(converted_json);
-        });
-        const statedistribution_url = `${config.apiUrl}/titles/title-xi/programs/crop-insurance/state-distribution`;
-        getJsonDataFromUrl(statedistribution_url).then((response) => {
-            setStateDistributionData(response);
-        });
+        const fetchData = async () => {
+            try {
+                const [allStatesResponse, stateCodesResponse, stateDistributionResponse] = await Promise.all([
+                    getJsonDataFromUrl(`${config.apiUrl}/states`),
+                    getJsonDataFromUrl(`${config.apiUrl}/statecodes`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-xi/programs/crop-insurance/state-distribution`)
+                ]);
+                setAllStatesData(allStatesResponse);
+                setStateCodesData(convertAllState(stateCodesResponse));
+                setStateDistributionData(stateDistributionResponse);
+                setIsDataReady(true);
+            } catch (error) {
+                console.error("Error fetching data:", error);
+            }
+        };
+        fetchData();
     }, []);
 
     const switchChartTable = (event, newTab) => {
@@ -87,9 +91,7 @@ export default function CropInsurancePage(): JSX.Element {
     };
     return (
         <ThemeProvider theme={defaultTheme}>
-            {Object.keys(stateCodesData).length > 0 &&
-            Object.keys(allStatesData).length > 0 &&
-            Object.keys(stateDistributionData).length > 0 ? (
+            {isDataReady ? (
                 <Box sx={{ width: "100%" }}>
                     <Box sx={{ position: "fixed", zIndex: 1400, width: "100%" }}>
                         <NavBar bkColor="rgba(255, 255, 255, 1)" ftColor="rgba(47, 113, 100, 1)" logo="light" />

--- a/src/pages/EQIPPage.tsx
+++ b/src/pages/EQIPPage.tsx
@@ -41,35 +41,32 @@ export default function EQIPPage(): JSX.Element {
     const [aTotal, setATotal] = React.useState(0);
     const [bTotal, setBTotal] = React.useState(0);
     const [zeroCategories, setZeroCategories] = React.useState([]);
+    const [isDataReady, setIsDataReady] = React.useState(false);
 
     const eqip_year = "2018-2022";
+
     React.useEffect(() => {
-        const state_perf_url = `${config.apiUrl}/titles/title-ii/programs/eqip/state-distribution`;
-        getJsonDataFromUrl(state_perf_url).then((response) => {
-            const converted_perf_json = response;
-            setStatePerformance(converted_perf_json);
-        });
-
-        const allstates_url = `${config.apiUrl}/states`;
-        getJsonDataFromUrl(allstates_url).then((response) => {
-            const converted_json = response;
-            setAllStates(converted_json);
-        });
-
-        const statecode_url = `${config.apiUrl}/statecodes`;
-        getJsonDataFromUrl(statecode_url).then((response) => {
-            setStateCodesArray(response);
-            const converted_json = convertAllState(response);
-            setStateCodesData(converted_json);
-        });
-
-        const chartdata_url = `${config.apiUrl}/titles/title-ii/programs/eqip/summary`;
-        getJsonDataFromUrl(chartdata_url).then((response) => {
-            const converted_chart_json = response;
-            processData(converted_chart_json);
-        });
+        const fetchData = async () => {
+            try {
+                const [statePerformanceResponse, allStatesResponse, stateCodesResponse, chartDataResponse] =
+                    await Promise.all([
+                        getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip/state-distribution`),
+                        getJsonDataFromUrl(`${config.apiUrl}/states`),
+                        getJsonDataFromUrl(`${config.apiUrl}/statecodes`),
+                        getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip/summary`)
+                    ]);
+                setStatePerformance(statePerformanceResponse);
+                setAllStates(allStatesResponse);
+                setStateCodesArray(stateCodesResponse);
+                setStateCodesData(convertAllState(stateCodesResponse));
+                processData(chartDataResponse);
+                setIsDataReady(true);
+            } catch (error) {
+                console.error("Error fetching data:", error);
+            }
+        };
+        fetchData();
     }, []);
-
     const processData = (chartData) => {
         if (chartData.statutes === undefined) return;
 
@@ -158,10 +155,7 @@ export default function EQIPPage(): JSX.Element {
 
     return (
         <ThemeProvider theme={defaultTheme}>
-            {allStates.length > 0 &&
-            statePerformance[eqip_year] !== undefined &&
-            zeroCategories.length > 0 &&
-            stateCodesArray.length > 0 ? (
+            {isDataReady ? (
                 <Box sx={{ width: "100%" }}>
                     <Box sx={{ position: "fixed", zIndex: 1400, width: "100%" }}>
                         <NavBar bkColor="rgba(255, 255, 255, 1)" ftColor="rgba(47, 113, 100, 1)" logo="light" />

--- a/src/pages/IRAPage.tsx
+++ b/src/pages/IRAPage.tsx
@@ -19,7 +19,7 @@ export default function IRAPage(): JSX.Element {
 
     // Fetching Data
     const [eqipStateDistributionData, setEqipStateDistributionData] = React.useState({});
-    const [eqipPredictedData, setEqipPredictedDData] = React.useState({});
+    const [eqipPredictedData, setEqipPredictedData] = React.useState({});
     const [eqipSummaryData, setEqipSummaryData] = React.useState({});
     const [eqipPracticeNames, setEqipPracticeNames] = React.useState({});
     const [stateCodesData, setStateCodesData] = React.useState({});
@@ -27,42 +27,39 @@ export default function IRAPage(): JSX.Element {
     const [allStatesData, setAllStatesData] = React.useState([]);
     const [zeroCategories, setZeroCategories] = React.useState([]);
     const [totalAcep, setTotalAcep] = React.useState(0);
+    const [isDataReady, setIsDataReady] = React.useState(false);
+
     React.useEffect(() => {
-        const allstates_url = `${config.apiUrl}/states`;
-        getJsonDataFromUrl(allstates_url).then((response) => {
-            setAllStatesData(response);
-        });
-
-        const statecode_url = `${config.apiUrl}/statecodes`;
-        getJsonDataFromUrl(statecode_url).then((response) => {
-            setStateCodesArray(response);
-            const converted_json = convertAllState(response);
-            setStateCodesData(converted_json);
-        });
-
-        // eqip IRA data
-        const eqip_statedistribution_url = `${config.apiUrl}/titles/title-ii/programs/eqip-ira/state-distribution`;
-        getJsonDataFromUrl(eqip_statedistribution_url).then((response) => {
-            setEqipStateDistributionData(response);
-        });
-        const eqip_predicted_url = `${config.apiUrl}/titles/title-ii/programs/eqip-ira/predicted`;
-        getJsonDataFromUrl(eqip_predicted_url).then((response) => {
-            setEqipPredictedDData(response);
-        });
-        const eqip_summary_url = `${config.apiUrl}/titles/title-ii/programs/eqip-ira/summary`;
-        getJsonDataFromUrl(eqip_summary_url).then((response) => {
-            setEqipSummaryData(response);
-        });
-        const eqip_practicenames_url = `${config.apiUrl}/titles/title-ii/programs/eqip-ira/practice-names`;
-        getJsonDataFromUrl(eqip_practicenames_url).then((response) => {
-            setEqipPracticeNames(response);
-        });
-
-        // csp IRA data
-
-        // rccp IRA data
-
-        // acep IRA data
+        const fetchData = async () => {
+            try {
+                const [
+                    allStatesResponse,
+                    stateCodesResponse,
+                    eqipStateDistributionResponse,
+                    eqipPredictedResponse,
+                    eqipSummaryResponse,
+                    eqipPracticeNamesResponse
+                ] = await Promise.all([
+                    getJsonDataFromUrl(`${config.apiUrl}/states`),
+                    getJsonDataFromUrl(`${config.apiUrl}/statecodes`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/state-distribution`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/predicted`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/summary`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/practice-names`)
+                ]);
+                setAllStatesData(allStatesResponse);
+                setStateCodesArray(stateCodesResponse);
+                setStateCodesData(convertAllState(stateCodesResponse));
+                setEqipStateDistributionData(eqipStateDistributionResponse);
+                setEqipPredictedData(eqipPredictedResponse);
+                setEqipSummaryData(eqipSummaryResponse);
+                setEqipPracticeNames(eqipPracticeNamesResponse);
+                setIsDataReady(true);
+            } catch (error) {
+                console.error("Error fetching data:", error);
+            }
+        };
+        fetchData();
     }, []);
 
     // Modal
@@ -112,8 +109,7 @@ export default function IRAPage(): JSX.Element {
                                 </Tabs>
                             </Box>
                             {/* NOTE: Because of divider, the index are increased by 2 */}
-                            {Object.keys(eqipStateDistributionData).length > 0 &&
-                            Object.keys(stateCodesData).length > 0 ? (
+                            {isDataReady ? (
                                 <span>
                                     <TabPanel
                                         v={value}

--- a/src/pages/SNAPPage.tsx
+++ b/src/pages/SNAPPage.tsx
@@ -44,33 +44,37 @@ export default function SNAPPage(): JSX.Element {
     const [allPrograms, setAllPrograms] = React.useState([]);
     const [allStates, setAllStates] = React.useState([]);
     const [summary, setSummary] = React.useState([]);
+    const [isDataReady, setIsDataReady] = React.useState(false);
 
     React.useEffect(() => {
-        const statecode_url = `${config.apiUrl}/statecodes`;
-        getJsonDataFromUrl(statecode_url).then((response) => {
-            const converted_json = convertAllState(response);
-            setStateCodes(converted_json);
-        });
-
-        const allprograms_url = `${config.apiUrl}/allprograms`;
-        getJsonDataFromUrl(allprograms_url).then((response) => {
-            setAllPrograms(response);
-        });
-
-        const allstates_url = `${config.apiUrl}/states`;
-        getJsonDataFromUrl(allstates_url).then((response) => {
-            setAllStates(response);
-        });
-
-        const summary_url = `${config.apiUrl}/summary`;
-        getJsonDataFromUrl(summary_url).then((response) => {
-            setSummary(response);
-        });
-
-        getJsonDataFromUrl(`${config.apiUrl}/titles/title-iv/programs/snap/state-distribution`).then((response) => {
-            setData(response);
-        });
+        const fetchData = async () => {
+            try {
+                const [
+                    stateCodesResponse,
+                    allProgramsResponse,
+                    allStatesResponse,
+                    summaryResponse,
+                    snapStateDistributionResponse
+                ] = await Promise.all([
+                    getJsonDataFromUrl(`${config.apiUrl}/statecodes`),
+                    getJsonDataFromUrl(`${config.apiUrl}/allprograms`),
+                    getJsonDataFromUrl(`${config.apiUrl}/states`),
+                    getJsonDataFromUrl(`${config.apiUrl}/summary`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-iv/programs/snap/state-distribution`)
+                ]);
+                setStateCodes(convertAllState(stateCodesResponse));
+                setAllPrograms(allProgramsResponse);
+                setAllStates(allStatesResponse);
+                setSummary(summaryResponse);
+                setData(snapStateDistributionResponse);
+                setIsDataReady(true);
+            } catch (error) {
+                console.error("Error fetching data:", error);
+            }
+        };
+        fetchData();
     }, []);
+
     const defaultTheme = createTheme({
         spacing: 8
     });
@@ -119,9 +123,7 @@ export default function SNAPPage(): JSX.Element {
     };
     return (
         <ThemeProvider theme={defaultTheme}>
-            {Object.keys(stateCodes).length > 0 &&
-            Object.keys(allStates).length > 0 &&
-            Object.keys(summary).length > 0 ? (
+            {isDataReady ? (
                 <Box sx={{ width: "100%" }}>
                     <Box sx={{ position: "fixed", zIndex: 1400, width: "100%" }}>
                         <NavBar bkColor="rgba(255, 255, 255, 1)" ftColor="rgba(47, 113, 100, 1)" logo="light" />

--- a/src/pages/TitleIIPage.tsx
+++ b/src/pages/TitleIIPage.tsx
@@ -16,41 +16,40 @@ export default function TitleIIPage(): JSX.Element {
     const [allPrograms, setAllPrograms] = React.useState([]);
     const [summary, setSummary] = React.useState([]);
     const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
-    const handleResize = () => {
-        setWindowWidth(window.innerWidth);
-    };
+    const [isDataReady, setIsDataReady] = React.useState(false);
 
     const total_year = "2018-2022";
     React.useEffect(() => {
-        // For landing page map only.
-        const allprograms_url = `${config.apiUrl}/allprograms`;
-        getJsonDataFromUrl(allprograms_url).then((response) => {
-            setAllPrograms(response);
-        });
-
-        const allstates_url = `${config.apiUrl}/states`;
-        getJsonDataFromUrl(allstates_url).then((response) => {
-            const converted_json = response;
-            setAllStates(converted_json);
-        });
-
-        const statecode_url = `${config.apiUrl}/statecodes`;
-        getJsonDataFromUrl(statecode_url).then((response) => {
-            const converted_json = convertAllState(response);
-            setStateCodesData(converted_json);
-        });
-
-        const summary_url = `${config.apiUrl}/summary`;
-        getJsonDataFromUrl(summary_url).then((response) => {
-            setSummary(response);
-        });
-
+        const fetchData = async () => {
+            try {
+                const [allProgramsResponse, allStatesResponse, stateCodesResponse, summaryResponse] = await Promise.all(
+                    [
+                        getJsonDataFromUrl(`${config.apiUrl}/allprograms`),
+                        getJsonDataFromUrl(`${config.apiUrl}/states`),
+                        getJsonDataFromUrl(`${config.apiUrl}/statecodes`),
+                        getJsonDataFromUrl(`${config.apiUrl}/summary`)
+                    ]
+                );
+                setAllPrograms(allProgramsResponse);
+                setAllStates(allStatesResponse);
+                setStateCodesData(convertAllState(stateCodesResponse));
+                setSummary(summaryResponse);
+                setIsDataReady(true);
+            } catch (error) {
+                console.error("Error fetching data:", error);
+            }
+        };
+        fetchData();
+        const handleResize = () => {
+            setWindowWidth(window.innerWidth);
+        };
         window.addEventListener("resize", handleResize);
         return () => window.removeEventListener("resize", handleResize);
     }, []);
+
     return (
         <ThemeProvider theme={defaultTheme}>
-            {allStates.length > 0 ? (
+            {isDataReady ? (
                 <Box sx={{ width: "100%" }}>
                     <Box sx={{ position: "fixed", zIndex: 1400, width: "100%" }}>
                         <NavBar bkColor="rgba(255, 255, 255, 1)" ftColor="rgba(47, 113, 100, 1)" logo="light" />

--- a/src/pages/TitleIPage.tsx
+++ b/src/pages/TitleIPage.tsx
@@ -30,7 +30,7 @@ export default function TitleIPage(): JSX.Element {
     const [subtitleDStateDistributionData, setSubtitleDStateDistributionData] = React.useState({});
     const [stateCodesData, setStateCodesData] = React.useState({});
     const [allStatesData, setAllStatesData] = React.useState([]);
-
+    const [isDataReady, setIsDataReady] = React.useState(false);
     const [allPrograms, setAllPrograms] = React.useState([]);
     const [summary, setSummary] = React.useState([]);
     const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
@@ -47,40 +47,40 @@ export default function TitleIPage(): JSX.Element {
     const subtitleAYear = "2014-2021";
     const subtitleEYear = "2014-2021";
     const subtitleDYear = "2014-2021";
+
     React.useEffect(() => {
-        // For landing page map only.
-        const allprograms_url = `${config.apiUrl}/allprograms`;
-        getJsonDataFromUrl(allprograms_url).then((response) => {
-            setAllPrograms(response);
-        });
-        const summary_url = `${config.apiUrl}/summary`;
-        getJsonDataFromUrl(summary_url).then((response) => {
-            setSummary(response);
-        });
-
-        const allstates_url = `${config.apiUrl}/states`;
-        getJsonDataFromUrl(allstates_url).then((response) => {
-            setAllStatesData(response);
-        });
-        const statecode_url = `${config.apiUrl}/statecodes`;
-        getJsonDataFromUrl(statecode_url).then((response) => {
-            const converted_json = convertAllState(response);
-            setStateCodesData(converted_json);
-        });
-        const subtitleA_url = `${config.apiUrl}/titles/title-i/subtitles/subtitle-a/state-distribution`;
-        getJsonDataFromUrl(subtitleA_url).then((response) => {
-            setSubtitleADistributionData(response);
-        });
-
-        const subtitleD_url = `${config.apiUrl}/titles/title-i/subtitles/subtitle-d/state-distribution`;
-        getJsonDataFromUrl(subtitleD_url).then((response) => {
-            setSubtitleDStateDistributionData(response);
-        });
-        const subtitleE_url = `${config.apiUrl}/titles/title-i/subtitles/subtitle-e/state-distribution`;
-        getJsonDataFromUrl(subtitleE_url).then((response) => {
-            setSubtitleEStateDistributionData(response);
-        });
-
+        const fetchData = async () => {
+            try {
+                const [
+                    allProgramsResponse,
+                    summaryResponse,
+                    allStatesResponse,
+                    stateCodesResponse,
+                    subtitleADistributionResponse,
+                    subtitleDStateDistributionResponse,
+                    subtitleEDistributionResponse
+                ] = await Promise.all([
+                    getJsonDataFromUrl(`${config.apiUrl}/allprograms`),
+                    getJsonDataFromUrl(`${config.apiUrl}/summary`),
+                    getJsonDataFromUrl(`${config.apiUrl}/states`),
+                    getJsonDataFromUrl(`${config.apiUrl}/statecodes`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-i/subtitles/subtitle-a/state-distribution`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-i/subtitles/subtitle-d/state-distribution`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-i/subtitles/subtitle-e/state-distribution`)
+                ]);
+                setAllPrograms(allProgramsResponse);
+                setSummary(summaryResponse);
+                setAllStatesData(allStatesResponse);
+                setStateCodesData(convertAllState(stateCodesResponse));
+                setSubtitleADistributionData(subtitleADistributionResponse);
+                setSubtitleDStateDistributionData(subtitleDStateDistributionResponse);
+                setSubtitleEStateDistributionData(subtitleEDistributionResponse);
+                setIsDataReady(true);
+            } catch (error) {
+                console.error("Error fetching data:", error);
+            }
+        };
+        fetchData();
         window.addEventListener("resize", handleResize);
         return () => window.removeEventListener("resize", handleResize);
     }, []);
@@ -148,11 +148,7 @@ export default function TitleIPage(): JSX.Element {
     };
     return (
         <ThemeProvider theme={defaultTheme}>
-            {Object.keys(stateCodesData).length > 0 &&
-            Object.keys(allStatesData).length > 0 &&
-            Object.keys(subtitleADistributionData).length > 0 &&
-            Object.keys(subtitleEStateDistributionData).length > 0 &&
-            Object.keys(subtitleDStateDistributionData).length > 0 ? (
+            {isDataReady ? (
                 <Box sx={{ width: "100%" }}>
                     <Box sx={{ position: "fixed", zIndex: 1400, width: "100%" }}>
                         <NavBar bkColor="rgba(255, 255, 255, 1)" ftColor="rgba(47, 113, 100, 1)" logo="light" />


### PR DESCRIPTION
This PR addresses issues #293 and #294:

1. Fixed the bug causing the IRA page to sometimes fail to load due to summary data arriving later than the component rendering.
2. I updated all pages on the PDL site in the same way to ensure they do not load before all necessary data is ready.
3. I cleaned up some syntax during this process to make the code more readable.

## How to Test

Open the site and check all pages. All pages should now render without any problems. Note that you may notice a slightly longer loading time for some components.