### PR TITLE
#293: prevent IRA page to load before data is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+- Fixed the occasional bug where the IRA page failed to load because the summary data was not ready [#293](https://github.com/policy-design-lab/pdl-frontend/issues/293) 
+
+
 ## [1.0.1] - 2024-07-19
 
 ### Added

--- a/src/pages/IRAPage.tsx
+++ b/src/pages/IRAPage.tsx
@@ -19,7 +19,7 @@ export default function IRAPage(): JSX.Element {
 
     // Fetching Data
     const [eqipStateDistributionData, setEqipStateDistributionData] = React.useState({});
-    const [eqipPredictedData, setEqipPredictedDData] = React.useState({});
+    const [eqipPredictedData, setEqipPredictedData] = React.useState({});
     const [eqipSummaryData, setEqipSummaryData] = React.useState({});
     const [eqipPracticeNames, setEqipPracticeNames] = React.useState({});
     const [stateCodesData, setStateCodesData] = React.useState({});
@@ -27,42 +27,39 @@ export default function IRAPage(): JSX.Element {
     const [allStatesData, setAllStatesData] = React.useState([]);
     const [zeroCategories, setZeroCategories] = React.useState([]);
     const [totalAcep, setTotalAcep] = React.useState(0);
+    const [isDataReady, setIsDataReady] = React.useState(false);
+
     React.useEffect(() => {
-        const allstates_url = `${config.apiUrl}/states`;
-        getJsonDataFromUrl(allstates_url).then((response) => {
-            setAllStatesData(response);
-        });
-
-        const statecode_url = `${config.apiUrl}/statecodes`;
-        getJsonDataFromUrl(statecode_url).then((response) => {
-            setStateCodesArray(response);
-            const converted_json = convertAllState(response);
-            setStateCodesData(converted_json);
-        });
-
-        // eqip IRA data
-        const eqip_statedistribution_url = `${config.apiUrl}/titles/title-ii/programs/eqip-ira/state-distribution`;
-        getJsonDataFromUrl(eqip_statedistribution_url).then((response) => {
-            setEqipStateDistributionData(response);
-        });
-        const eqip_predicted_url = `${config.apiUrl}/titles/title-ii/programs/eqip-ira/predicted`;
-        getJsonDataFromUrl(eqip_predicted_url).then((response) => {
-            setEqipPredictedDData(response);
-        });
-        const eqip_summary_url = `${config.apiUrl}/titles/title-ii/programs/eqip-ira/summary`;
-        getJsonDataFromUrl(eqip_summary_url).then((response) => {
-            setEqipSummaryData(response);
-        });
-        const eqip_practicenames_url = `${config.apiUrl}/titles/title-ii/programs/eqip-ira/practice-names`;
-        getJsonDataFromUrl(eqip_practicenames_url).then((response) => {
-            setEqipPracticeNames(response);
-        });
-
-        // csp IRA data
-
-        // rccp IRA data
-
-        // acep IRA data
+        const fetchData = async () => {
+            try {
+                const [
+                    allStatesResponse,
+                    stateCodesResponse,
+                    eqipStateDistributionResponse,
+                    eqipPredictedResponse,
+                    eqipSummaryResponse,
+                    eqipPracticeNamesResponse
+                ] = await Promise.all([
+                    getJsonDataFromUrl(`${config.apiUrl}/states`),
+                    getJsonDataFromUrl(`${config.apiUrl}/statecodes`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/state-distribution`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/predicted`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/summary`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/practice-names`)
+                ]);
+                setAllStatesData(allStatesResponse);
+                setStateCodesArray(stateCodesResponse);
+                setStateCodesData(convertAllState(stateCodesResponse));
+                setEqipStateDistributionData(eqipStateDistributionResponse);
+                setEqipPredictedData(eqipPredictedResponse);
+                setEqipSummaryData(eqipSummaryResponse);
+                setEqipPracticeNames(eqipPracticeNamesResponse);
+                setIsDataReady(true);
+            } catch (error) {
+                console.error("Error fetching data:", error);
+            }
+        };
+        fetchData();
     }, []);
 
     // Modal
@@ -112,8 +109,7 @@ export default function IRAPage(): JSX.Element {
                                 </Tabs>
                             </Box>
                             {/* NOTE: Because of divider, the index are increased by 2 */}
-                            {Object.keys(eqipStateDistributionData).length > 0 &&
-                            Object.keys(stateCodesData).length > 0 ? (
+                            {isDataReady ? (
                                 <span>
                                     <TabPanel
                                         v={value}


### PR DESCRIPTION
This PR addresses issues https://github.com/policy-design-lab/pdl-frontend/issues/293. It fixed the bug causing the IRA page to sometimes fail to load due to summary data arriving later than the component rendering.

## How to Test

This PR has been deployed to the dev site. Open the site and check the IRA pages. It should load without any problem.