### PR TITLE
#306: Block the IRA page modal to automatically open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+- Block the EQIP IRA information modal from opening automatically when the page loads due to the size of the article's iframe. [#306](https://github.com/policy-design-lab/pdl-frontend/issues/306) 
+
 ## [1.0.2] - 2024-07-23
 
 ### Fixed

--- a/src/pages/IRAPage.tsx
+++ b/src/pages/IRAPage.tsx
@@ -64,7 +64,7 @@ export default function IRAPage(): JSX.Element {
 
     // Modal
     React.useEffect(() => {
-        //setModalOpen(true); // #306: Block the model to be auto-opened due to the size of iframe
+        // setModalOpen(true); // #306: Block the model to be auto-opened due to the size of iframe
     }, []);
     const handleOpen = () => {
         setModalOpen(true);

--- a/src/pages/IRAPage.tsx
+++ b/src/pages/IRAPage.tsx
@@ -64,7 +64,7 @@ export default function IRAPage(): JSX.Element {
 
     // Modal
     React.useEffect(() => {
-        setModalOpen(true);
+        //setModalOpen(true); // #306: Block the model to be auto-opened due to the size of iframe
     }, []);
     const handleOpen = () => {
         setModalOpen(true);


### PR DESCRIPTION
This PR is for #306. Due to the iframe size of the article, the information modal for the EQIP IRA page can block the entire iframe view. This PR disables this feature. The audience can still click the 'info' icon to open the modal.

## How to Test
1. Navigate to the IRA page. The information modal should not pop up.
2. Click the information icon near "EQIP." The modal should open as expected.