### PR TITLE
Release 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [1.0.3] - 2024-08-01
 
 ### Fixed
 - Block the EQIP IRA information modal from opening automatically when the page loads due to the size of the article's iframe. [#306](https://github.com/policy-design-lab/pdl-frontend/issues/306) 
@@ -268,6 +268,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Map data json [#12](https://github.com/policy-design-lab/pdl-frontend/issues/12)
 - Final landing page changes for initial milestone [#15](https://github.com/policy-design-lab/pdl-frontend/issues/15)
 
+[1.0.3]: https://github.com/policy-design-lab/pdl-frontend/compare/1.0.2...1.0.3
 [1.0.2]: https://github.com/policy-design-lab/pdl-frontend/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/policy-design-lab/pdl-frontend/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/policy-design-lab/pdl-frontend/compare/0.20.0...1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "policy-design-lab",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "policy-design-lab",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "the front end of policy design lab",
   "repository": "https://github.com/policy-design-lab/pdl-frontend",
   "main": "src/app.tsx",


### PR DESCRIPTION
## [1.0.3] - 2024-08-01

### Fixed
- Block the EQIP IRA information modal from opening automatically when the page loads due to the size of the article's iframe. [#306](https://github.com/policy-design-lab/pdl-frontend/issues/306) 