### PR TITLE
CSP IRA Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [unreleased]
 
 ### Added
+- Added the CSP session to the IRA page [#299](https://github.com/policy-design-lab/pdl-frontend/issues/299) 
+- Improved the map legend to cover more maps on the IRA page [#313](https://github.com/policy-design-lab/pdl-frontend/issues/313) 
+
+## [1.0.4] - 2024-08-16
+
+### Added
 - Added the top info session for IRA page [#309](https://github.com/policy-design-lab/pdl-frontend/issues/309) 
 - Added "Other CSP" statues and related categories to the CSP pages [#303](https://github.com/policy-design-lab/pdl-frontend/issues/303) 
 - Added null value handling for the latest CSP data [#301](https://github.com/policy-design-lab/pdl-frontend/issues/301) 
@@ -280,6 +286,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Map data json [#12](https://github.com/policy-design-lab/pdl-frontend/issues/12)
 - Final landing page changes for initial milestone [#15](https://github.com/policy-design-lab/pdl-frontend/issues/15)
 
+[1.0.4]: https://github.com/policy-design-lab/pdl-frontend/compare/1.0.3...1.0.4
 [1.0.3]: https://github.com/policy-design-lab/pdl-frontend/compare/1.0.2...1.0.3
 [1.0.2]: https://github.com/policy-design-lab/pdl-frontend/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/policy-design-lab/pdl-frontend/compare/1.0.0...1.0.1

--- a/src/components/ira/IRADollarMap.tsx
+++ b/src/components/ira/IRADollarMap.tsx
@@ -484,13 +484,14 @@ const IRADollarMap = ({
     // since IRA data is not predictable in legend config, separate the scale to five equal parts
     const sortedData = quantizeArray.sort((a, b) => a - b);
     const numIntervals = 5;
-    const intervalSize = Math.floor(sortedData.length / numIntervals);
-    const thresholds = [];
+    const nonZeroData = sortedData.filter((value) => value > 0);
+    const intervalSize = Math.ceil(nonZeroData.length / numIntervals);
+    const thresholds: number[] = [];
     for (let i = 1; i < numIntervals; i += 1) {
         const thresholdIndex = i * intervalSize - 1;
-        thresholds.push(sortedData[thresholdIndex]);
+        const adjustedIndex = Math.min(thresholdIndex, nonZeroData.length - 1);
+        thresholds.push(nonZeroData[adjustedIndex]);
     }
-    if (thresholds[0] === 0) thresholds.unshift(1000);
     const colorScale = d3.scaleThreshold().domain(thresholds).range(mapColor);
     // For IRA, only if all practices are zero, the state will be colored as grey
     let zeroPoints = [];

--- a/src/components/ira/IRAPredictedMap.tsx
+++ b/src/components/ira/IRAPredictedMap.tsx
@@ -321,13 +321,14 @@ const IRAPredictedMap = ({
     // since IRA data is not predictable in legend config, separate the scale to five equal parts
     const sortedData = quantizeArray.sort((a, b) => a - b);
     const numIntervals = 5;
-    const intervalSize = Math.floor(sortedData.length / numIntervals);
-    const thresholds = [];
+    const nonZeroData = sortedData.filter((value) => value > 0);
+    const intervalSize = Math.ceil(nonZeroData.length / numIntervals);
+    const thresholds: number[] = [];
     for (let i = 1; i < numIntervals; i += 1) {
         const thresholdIndex = i * intervalSize - 1;
-        thresholds.push(sortedData[thresholdIndex]);
+        const adjustedIndex = Math.min(thresholdIndex, nonZeroData.length - 1);
+        thresholds.push(nonZeroData[adjustedIndex]);
     }
-    if (thresholds[0] === 0) thresholds.unshift(1000);
     const colorScale = d3.scaleThreshold().domain(thresholds).range(mapColor);
     // For IRA, only if all practices are zero, the state will be colored as grey
     let zeroPoints = [];

--- a/src/components/ira/TabPanel.tsx
+++ b/src/components/ira/TabPanel.tsx
@@ -55,7 +55,7 @@ function TabPanel({
     const years = stateDistributionData ? Object.keys(stateDistributionData).map(Number) : [];
     const [updatedData, setUpdatedData] = useState(stateDistributionData);
     const [updatedPredictedData, setUpdatedPredictedData] = useState(predictedData);
-    const minYear = Math.min(...years).toString();
+    const minYear = 2023;
     const maxYear = Math.max(...years);
     const [isPlaying, setIsPlaying] = useState(false);
     const [intervalId, setIntervalId] = useState<ReturnType<typeof setInterval> | null>(null);

--- a/src/components/shared/ConvertionFormats.tsx
+++ b/src/components/shared/ConvertionFormats.tsx
@@ -36,10 +36,14 @@ export function ShortFormat(labelValue, position?: number, decimal?: number) {
     }
     if (decimalPart.length > 0) {
         const numberPart = result.match(/^(.*).$/)?.[1];
+        if (position === -1) {
+            return result;
+        }
         if (position === 0) {
-            result = result.replace(/^(.*)(.)$/, `${Math.floor(Number(numberPart))}$2`);
-        } else if (position !== undefined) {
-            result = result.replace(/^(.*)(.)$/, `${Math.ceil(Number(numberPart))}$2`);
+            return result.replace(/^(.*)(.)$/, `${Math.floor(Number(numberPart))}$2`);
+        }
+        if (position !== undefined) {
+            return result.replace(/^(.*)(.)$/, `${Math.ceil(Number(numberPart))}$2`);
         }
     }
     return result;

--- a/src/components/shared/DrawLegend.tsx
+++ b/src/components/shared/DrawLegend.tsx
@@ -112,10 +112,10 @@ export default function DrawLegend({
                                     return `${Math.round(cut_points[i] * 100)}%`;
                                 }
                                 if (i === 0 && !notDollar) {
-                                    const res = ShortFormat(Math.round(cut_points[i]), i);
+                                    const res = ShortFormat(cut_points[i].toFixed(2), -1, 2);
                                     return res.indexOf("-") < 0 ? `$${res}` : `-$${res.substring(1)}`;
                                 }
-                                return ShortFormat(Math.round(cut_points[i]), i, 1);
+                                return ShortFormat(cut_points[i].toFixed(2), -1, 2);
                             });
                     } else {
                         baseSVG
@@ -136,10 +136,10 @@ export default function DrawLegend({
                                     return `${Math.round(cut_points[i] * 100)}%`;
                                 }
                                 if (i === 0 && !notDollar) {
-                                    const res = ShortFormat(Math.round(cut_points[i]), i);
+                                    const res = ShortFormat(cut_points[i].toFixed(2), -1, 2);
                                     return res.indexOf("-") < 0 ? `$${res}` : `-$${res.substring(1)}`;
                                 }
-                                return ShortFormat(Math.round(cut_points[i]), i, 2);
+                                return ShortFormat(cut_points[i].toFixed(2), -1, 2);
                             });
                     }
                     if (emptyState.length !== 0) {

--- a/src/pages/IRAPage.tsx
+++ b/src/pages/IRAPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, Grid, Tabs, Button } from "@mui/material";
+import { Box, Typography, Grid, Tabs, Button, Divider } from "@mui/material";
 import * as React from "react";
 import { config } from "../app.config";
 import { convertAllState, getJsonDataFromUrl } from "../utils/apiutil";
@@ -21,6 +21,10 @@ export default function IRAPage(): JSX.Element {
     const [eqipPredictedData, setEqipPredictedData] = React.useState({});
     const [eqipSummaryData, setEqipSummaryData] = React.useState({});
     const [eqipPracticeNames, setEqipPracticeNames] = React.useState({});
+    const [cspStateDistributionData, setCspStateDistributionData] = React.useState({});
+    const [cspPredictedData, setCspPredictedData] = React.useState({});
+    const [cspSummaryData, setCspSummaryData] = React.useState({});
+    const [cspPracticeNames, setCspPracticeNames] = React.useState({});
     const [stateCodesData, setStateCodesData] = React.useState({});
     const [stateCodesArray, setStateCodesArray] = React.useState({});
     const [allStatesData, setAllStatesData] = React.useState([]);
@@ -37,14 +41,22 @@ export default function IRAPage(): JSX.Element {
                     eqipStateDistributionResponse,
                     eqipPredictedResponse,
                     eqipSummaryResponse,
-                    eqipPracticeNamesResponse
+                    eqipPracticeNamesResponse,
+                    cspStateDistributionResponse,
+                    cspPredictedResponse,
+                    cspSummaryResponse,
+                    cspPracticeNamesResponse
                 ] = await Promise.all([
                     getJsonDataFromUrl(`${config.apiUrl}/states`),
                     getJsonDataFromUrl(`${config.apiUrl}/statecodes`),
                     getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/state-distribution`),
                     getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/predicted`),
                     getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/summary`),
-                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/practice-names`)
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/eqip-ira/practice-names`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/csp-ira/state-distribution`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/csp-ira/predicted`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/csp-ira/summary`),
+                    getJsonDataFromUrl(`${config.apiUrl}/titles/title-ii/programs/csp-ira/practice-names`)
                 ]);
                 setAllStatesData(allStatesResponse);
                 setStateCodesArray(stateCodesResponse);
@@ -53,6 +65,10 @@ export default function IRAPage(): JSX.Element {
                 setEqipPredictedData(eqipPredictedResponse);
                 setEqipSummaryData(eqipSummaryResponse);
                 setEqipPracticeNames(eqipPracticeNamesResponse);
+                setCspStateDistributionData(cspStateDistributionResponse);
+                setCspPredictedData(cspPredictedResponse);
+                setCspSummaryData(cspSummaryResponse);
+                setCspPracticeNames(cspPracticeNamesResponse);
                 setIsDataReady(true);
             } catch (error) {
                 console.error("Error fetching data:", error);
@@ -167,9 +183,9 @@ export default function IRAPage(): JSX.Element {
                                     sx={{ mb: 1 }}
                                 >
                                     <CustomTab label={<Box>EQIP</Box>} customSx={tabStyle} selectedSX={selectedStyle} />
+                                    <Divider sx={{ mx: 1 }} orientation="vertical" variant="middle" flexItem />
+                                    <CustomTab label={<Box>CSP</Box>} customSx={tabStyle} selectedSX={selectedStyle} />
                                     {/* <Divider sx={{ mx: 1 }} orientation="vertical" variant="middle" flexItem />
-                    <CustomTab label={<Box>CSP</Box>} customSx={tabStyle} selectedSX={selectedStyle} />
-                    <Divider sx={{ mx: 1 }} orientation="vertical" variant="middle" flexItem />
                     <CustomTab label={<Box>RCPP</Box>} customSx={tabStyle} selectedSX={selectedStyle} />
                     <Divider sx={{ mx: 1 }} orientation="vertical" variant="middle" flexItem />
                     <CustomTab label={<Box>ACEP</Box>} customSx={tabStyle} selectedSX={selectedStyle} /> */}
@@ -191,8 +207,19 @@ export default function IRAPage(): JSX.Element {
                                         allStates={allStatesData}
                                         summaryData={eqipSummaryData}
                                     />
-                                    {/* <TabPanel v={value} index={2} title="CSP" stateDistributionData={{}} />
-                    <TabPanel v={value} index={4} title="RCPP" stateDistributionData={{}} />
+                                    <TabPanel
+                                        v={value}
+                                        index={2}
+                                        title="CSP"
+                                        stateDistributionData={cspStateDistributionData}
+                                        predictedData={cspPredictedData}
+                                        predictedYear={Object.keys(cspPredictedData)[0]}
+                                        stateCodes={stateCodesData}
+                                        allStates={allStatesData}
+                                        practiceNames={cspPracticeNames}
+                                        summaryData={cspSummaryData}
+                                    />
+                                    {/* <TabPanel v={value} index={4} title="RCPP" stateDistributionData={{}} />
                     <TabPanel v={value} index={6} title="ACEP" stateDistributionData={{}} /> */}
                                 </span>
                             ) : (


### PR DESCRIPTION
This PR is for #299 and #313, including the main CSP IRA page and map legend enhancements for maps on the IRA page. The collaborator has verified the data via the dev instance.

## How to Test

1. Navigate to https://policydesignlab-dev.ncsa.illinois.edu/ira and open the "CSP" tab

2. Check the map to ensure the data is correctly displayed.
<img width="1805" alt="Screenshot 2024-08-28 at 8 49 32 AM" src="https://github.com/user-attachments/assets/04fda811-971a-4d06-ae72-a0d970d503fd">

3. Scroll to the bottom of the page to check that the table is correctly displayed, including both the dollar table and the corresponding nationwide percentage table.

4. When you click the 'Export this Table to CSV' button, you should be able to download a CSV file named 'pdl-data' for this table. Verify that the data in the downloaded CSV file is correct (In the future, I plan to update the solution so that the file names differ based on the table)

5. Now navigate to the right side of the page and select random practices instead of Total. You should see the map and tables reflect the updated information. Repeat steps 2 to 4:
<img width="1635" alt="Screenshot 2024-08-28 at 8 50 41 AM" src="https://github.com/user-attachments/assets/fa1b25a3-6866-43b9-abdb-787619e3a592">

6. Now turn the "2024-2031 Prediction" switch on. You should see all data become the predicted data. The map and tables should reflect the changes. Repeat steps 2 to 4:
<img width="1655" alt="Screenshot 2024-08-28 at 8 51 32 AM" src="https://github.com/user-attachments/assets/721d8dde-ccfa-465c-ad1f-05381853ae1d">
