### PR TITLE
#344, #345 and #341: change to "gray" | fix the map tip loading problem and changing comma to delimiter on EQIP & CSP total page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Changed all 'grey' word of the site into 'gray' to accommodate US language practice [#341](https://github.com/policy-design-lab/pdl-frontend/issues/341) 
+- Changed comma-handled multi-practice selecting query to delimiter-handled query for EQIP and CSP total page selector [#344](https://github.com/policy-design-lab/pdl-frontend/issues/344) 
 
 ### Fixed
 - Fixed the bug where the map tips lagged in rendering HTML code and processing styles on the EQIP and CSO total page [#345](https://github.com/policy-design-lab/pdl-frontend/issues/345) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+- Changed all 'grey' word of the site into 'gray' to accommodate US language practice [#341](https://github.com/policy-design-lab/pdl-frontend/issues/341) 
+
+### Fixed
+- Fixed the bug where the map tips lagged in rendering HTML code and processing styles on the EQIP and CSO total page [#345](https://github.com/policy-design-lab/pdl-frontend/issues/345) 
+
 ## [1.4.0] - 2024-11-26
 
 ### Added

--- a/src/components/acep/ACEPTotalMap.tsx
+++ b/src/components/acep/ACEPTotalMap.tsx
@@ -235,7 +235,7 @@ const titleElement = (attribute, year): JSX.Element => {
                 <strong>{attribute}</strong> Benefits from <strong>{year}</strong>
             </Typography>{" "}
             <Typography noWrap style={{ fontSize: "0.5em", color: "#AAA", textAlign: "center" }}>
-                <i>In any state that appears in grey, there is no available data</i>
+                <i>In any state that appears in gray, there is no available data</i>
             </Typography>
         </Box>
     );

--- a/src/components/crp/CRPTotalMap.tsx
+++ b/src/components/crp/CRPTotalMap.tsx
@@ -242,7 +242,7 @@ const titleElement = (attribute, year): JSX.Element => {
                 <strong>{attribute}</strong> Benefits from <strong>{year}</strong>
             </Typography>{" "}
             <Typography noWrap style={{ fontSize: "0.5em", color: "#AAA", textAlign: "center" }}>
-                <i>In any state that appears in grey, there is no available data</i>
+                <i>In any state that appears in gray, there is no available data</i>
             </Typography>
         </Box>
     );

--- a/src/components/crp/CategoryMap.tsx
+++ b/src/components/crp/CategoryMap.tsx
@@ -316,7 +316,7 @@ const titleElement = (attribute, year): JSX.Element => {
                 <strong>{attribute}</strong> Benefits from <strong>{year}</strong>
             </Typography>{" "}
             <Typography noWrap style={{ fontSize: "0.5em", color: "#AAA", textAlign: "center" }}>
-                <i>In any state that appears in grey, there is no available data</i>
+                <i>In any state that appears in gray, there is no available data</i>
             </Typography>
         </Box>
     );

--- a/src/components/csp/CategoryMap.tsx
+++ b/src/components/csp/CategoryMap.tsx
@@ -290,7 +290,7 @@ const titleElement = (attribute, year): JSX.Element => {
                 <strong>{attribute}</strong> Benefits from <strong>{year}</strong>
             </Typography>{" "}
             <Typography noWrap style={{ fontSize: "0.5em", color: "#AAA", textAlign: "center" }}>
-                <i>In any state that appears in grey, there is no available data</i>
+                <i>In any state that appears in gray, there is no available data</i>
             </Typography>
         </Box>
     );

--- a/src/components/eqip/CategoryMap.tsx
+++ b/src/components/eqip/CategoryMap.tsx
@@ -236,7 +236,7 @@ const titleElement = (attribute, year): JSX.Element => {
                 <strong>{attribute}</strong> Benefits from <strong>{year}</strong>
             </Typography>{" "}
             <Typography noWrap style={{ fontSize: "0.5em", color: "#AAA", textAlign: "center" }}>
-                <i>In any state that appears in grey, there is no available data</i>
+                <i>In any state that appears in gray, there is no available data</i>
             </Typography>
         </Box>
     );

--- a/src/components/ira/IRADollarMap.tsx
+++ b/src/components/ira/IRADollarMap.tsx
@@ -493,7 +493,7 @@ const IRADollarMap = ({
         thresholds.push(nonZeroData[adjustedIndex]);
     }
     const colorScale = d3.scaleThreshold().domain(thresholds).range(mapColor);
-    // For IRA, only if all practices are zero, the state will be colored as grey
+    // For IRA, only if all practices are zero, the state will be colored as gray
     let zeroPoints = [];
     statePerformance[year].forEach((state) => {
         if (practices[0] === "Total") {

--- a/src/components/ira/IRAPredictedMap.tsx
+++ b/src/components/ira/IRAPredictedMap.tsx
@@ -330,7 +330,7 @@ const IRAPredictedMap = ({
         thresholds.push(nonZeroData[adjustedIndex]);
     }
     const colorScale = d3.scaleThreshold().domain(thresholds).range(mapColor);
-    // For IRA, only if all practices are zero, the state will be colored as grey
+    // For IRA, only if all practices are zero, the state will be colored as gray
     let zeroPoints = [];
     predictedPerformance[year].forEach((state) => {
         if (practices[0] === "Total") {

--- a/src/components/rcpp/RCPPTotalMap.tsx
+++ b/src/components/rcpp/RCPPTotalMap.tsx
@@ -243,7 +243,7 @@ const titleElement = (attribute, year): JSX.Element => {
                 <strong>{attribute}</strong> Benefits from <strong>{year}</strong>
             </Typography>{" "}
             <Typography noWrap style={{ fontSize: "0.5em", color: "#AAA", textAlign: "center" }}>
-                <i>In any state that appears in grey, there is no available data</i>
+                <i>In any state that appears in gray, there is no available data</i>
             </Typography>
         </Box>
     );

--- a/src/components/shared/DrawLegend.tsx
+++ b/src/components/shared/DrawLegend.tsx
@@ -164,7 +164,7 @@ export default function DrawLegend({
                             .attr("class", "legendTextSide")
                             .attr("x", -1000)
                             .attr("y", -1000)
-                            .text("In any state that appears in grey, there is no available data");
+                            .text("In any state that appears in gray, there is no available data");
                         const middleBox = middleText.node().getBBox();
                         middleText.remove();
                         baseSVG
@@ -172,7 +172,7 @@ export default function DrawLegend({
                             .attr("class", "legendTextSide")
                             .attr("x", (svgWidth + margin * 2) / 2 - middleBox.width / 2)
                             .attr("y", 80)
-                            .text("In any state that appears in grey, there is no available data");
+                            .text("In any state that appears in gray, there is no available data");
                     }
                 } else {
                     baseSVG.attr("height", 40);

--- a/src/components/shared/titleii/TitleIIPracticeMap.tsx
+++ b/src/components/shared/titleii/TitleIIPracticeMap.tsx
@@ -132,20 +132,6 @@ const MapChart = ({
         </div>
     );
 };
-
-function encodeQueryParams(params) {
-    return Object.entries(params)
-        .map(([key, value]) => {
-            const encodedValue = encodeURIComponent(value);
-            return `${key}=${encodedValue}`;
-        })
-        .join("&");
-}
-
-function buildURL(baseUrl, params) {
-    const encodedParams = encodeQueryParams(params);
-    return `${baseUrl}?${encodedParams}`;
-}
 const TitleIIPracticeMap = ({
     programName,
     initialStatePerformance,
@@ -217,7 +203,7 @@ const TitleIIPracticeMap = ({
                 setStatePerformance(initialStatePerformance);
                 return;
             }
-            const encodedCodes = selectedCodes.map((code) => encodeURIComponent(code)).join(",");
+            const encodedCodes = selectedCodes.map((code) => encodeURIComponent(code)).join("|");
             const url = `${
                 config.apiUrl
             }/titles/title-ii/programs/${programName.toLowerCase()}/state-distribution?practice_code=${encodedCodes}`;

--- a/src/components/shared/titleii/TitleIIPracticeMap.tsx
+++ b/src/components/shared/titleii/TitleIIPracticeMap.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from "react";
+import { CircularProgress } from "@mui/material";
 import { geoCentroid } from "d3-geo";
 import { ComposableMap, Geographies, Geography, Marker, Annotation } from "react-simple-maps";
 import ReactTooltip from "react-tooltip";
@@ -48,11 +49,22 @@ const MapChart = ({
     year,
     stateCodes,
     colorScale,
-    selectedPractices
+    selectedPractices,
+    classes
 }) => {
-    const classes = useStyles();
+    const handleMouseEnter = React.useCallback(
+        (geo, record) => {
+            const tooltipContent = computeTooltipContent(geo, record, selectedPractices, classes, getNationalTotal);
+            setReactTooltipContent(tooltipContent);
+        },
+        [selectedPractices, classes, getNationalTotal]
+    );
+    const handleMouseLeave = React.useCallback(() => {
+        setReactTooltipContent("");
+    }, []);
+
     return (
-        <div data-tip="">
+        <div data-tip="" data-for="map-tooltip">
             <ComposableMap projection="geoAlbersUsa">
                 <Geographies geography={geoUrl}>
                     {({ geographies }) => (
@@ -73,18 +85,8 @@ const MapChart = ({
                                     <Geography
                                         key={geo.rsmKey}
                                         geography={geo}
-                                        onMouseEnter={() => {
-                                            const tooltipContent = computeTooltipContent(
-                                                geo,
-                                                record,
-                                                selectedPractices,
-                                                classes,
-                                                getNationalTotal
-                                            );
-                                            ReactTooltip.rebuild();
-                                            setReactTooltipContent(tooltipContent);
-                                        }}
-                                        onMouseLeave={() => setReactTooltipContent("")}
+                                        onMouseEnter={() => handleMouseEnter(geo, record)}
+                                        onMouseLeave={handleMouseLeave}
                                         fill={colorScale(practiceTotal || 0) || "#D2D2D2"}
                                         stroke="#FFF"
                                         style={{
@@ -158,6 +160,38 @@ const TitleIIPracticeMap = ({
     const classes = useStyles();
     const [selectedPractices, setSelectedPractices] = useState<string[]>(["All Practices"]);
     const [isLoading, setIsLoading] = useState(false);
+    const [tooltipVisible, setTooltipVisible] = useState(false);
+    // help tooltip style to load without lag
+    React.useEffect(() => {
+        if (content) {
+            ReactTooltip.hide();
+            ReactTooltip.rebuild();
+            setTooltipVisible(true);
+        } else {
+            setTooltipVisible(false);
+        }
+    }, [content]);
+    React.useEffect(() => {
+        const style = document.createElement("style");
+        style.innerHTML = `
+            .__react_component_tooltip {
+                padding: 0 !important;
+                margin: 0 !important;
+                opacity: 1 !important;
+            }
+            .__react_component_tooltip.show {
+                opacity: 1 !important;
+            }
+        `;
+        document.head.appendChild(style);
+        return () => {
+            ReactTooltip.hide();
+            document.head.removeChild(style);
+        };
+    }, []);
+    const setTooltipContent = React.useCallback((newContent) => {
+        setContent(newContent);
+    }, []);
 
     const practiceCategories = useMemo(() => {
         return getPracticeCategories(practiceNames);
@@ -214,11 +248,6 @@ const TitleIIPracticeMap = ({
         }
         fetchStatePerformanceData(newSelected);
     };
-
-    React.useEffect(() => {
-        ReactTooltip.rebuild();
-    }, [statePerformance, selectedPractices]);
-
     const practiceData = useMemo(() => {
         return getPracticeData(statePerformance, year, selectedPractices);
     }, [statePerformance, year, selectedPractices]);
@@ -247,6 +276,38 @@ const TitleIIPracticeMap = ({
         }
         fetchStatePerformanceData(newSelected);
     };
+    const tooltipComponent = useMemo(
+        () => (
+            <ReactTooltip
+                id="map-tooltip"
+                className={`${classes.customized_tooltip} tooltip`}
+                backgroundColor={tooltipBkgColor}
+                effect="float"
+                html
+                getContent={() => (tooltipVisible ? content : null)}
+                overridePosition={({ left, top }, _e, _t, node) => {
+                    const viewportWidth = window.innerWidth;
+                    const viewportHeight = window.innerHeight;
+                    if (!node) return { left, top };
+                    const tooltipRect = node.getBoundingClientRect();
+
+                    let updatedLeft = left;
+                    let updatedTop = top;
+
+                    if (left + tooltipRect.width > viewportWidth) {
+                        updatedLeft = viewportWidth - tooltipRect.width - 10;
+                    }
+                    if (top + tooltipRect.height > viewportHeight) {
+                        updatedTop = viewportHeight - tooltipRect.height - 10;
+                    }
+
+                    return { left: updatedLeft, top: updatedTop };
+                }}
+            />
+        ),
+        [classes, content, tooltipVisible]
+    );
+
     const shouldShowLoading = isLoading && !selectedPractices.includes("All Practices");
     const hasValidData = statePerformance && statePerformance[year] && statePerformance[year].length > 0;
     if (!hasValidData && !shouldShowLoading) {
@@ -349,32 +410,27 @@ const TitleIIPracticeMap = ({
 
             {shouldShowLoading ? (
                 <Box display="flex" justifyContent="center" mt={4}>
-                    <Typography>Loading data...</Typography>
+                    <CircularProgress />
                 </Box>
             ) : (
                 hasValidData && (
-                    <MapChart
-                        getNationalTotal={getNationalTotal}
-                        setReactTooltipContent={setContent}
-                        maxValue={maxValue}
-                        allStates={allStates}
-                        statePerformance={statePerformance}
-                        year={year}
-                        stateCodes={stateCodes}
-                        colorScale={colorScale}
-                        selectedPractices={selectedPractices}
-                    />
+                    <>
+                        <MapChart
+                            getNationalTotal={getNationalTotal}
+                            setReactTooltipContent={setTooltipContent}
+                            maxValue={maxValue}
+                            allStates={allStates}
+                            statePerformance={statePerformance}
+                            year={year}
+                            stateCodes={stateCodes}
+                            colorScale={colorScale}
+                            selectedPractices={selectedPractices}
+                            classes={classes}
+                        />
+                        {tooltipComponent}
+                    </>
                 )
             )}
-            <div className="tooltip-container">
-                <ReactTooltip
-                    className={`${classes.customized_tooltip} tooltip`}
-                    backgroundColor={tooltipBkgColor}
-                    html
-                >
-                    {content}
-                </ReactTooltip>
-            </div>
         </Box>
     );
 };
@@ -384,11 +440,11 @@ const titleElement = (programName, practices: string[], year: string): JSX.Eleme
     return (
         <Box>
             <Typography variant="h6" textAlign="center">
-                <strong>{practiceLabel === "All Practices" ? `Total ${programName}` : practiceLabel}</strong> Benefits
-                from <strong>{year}</strong>
+                <strong>{practiceLabel === "All Practices" ? `Total ${programName}` : "Selected Practices"}</strong>{" "}
+                Benefits from <strong>{year}</strong>
             </Typography>
             <Typography style={{ fontSize: "0.5em", color: "#AAA", textAlign: "center" }}>
-                <i>Grey states indicate no available data</i>
+                <i>Gray states indicate no available data</i>
             </Typography>
         </Box>
     );

--- a/src/components/shared/titleii/TitleIIPracticeTable.tsx
+++ b/src/components/shared/titleii/TitleIIPracticeTable.tsx
@@ -180,83 +180,97 @@ function Table({ programName, columns, data }) {
                     </Box>
                     <table {...getTableProps()} style={{ width: "100%", tableLayout: "fixed" }}>
                         <thead>
-                            {headerGroups.map((headerGroup) => (
-                                <tr {...headerGroup.getHeaderGroupProps()} key={headerGroup}>
-                                    <th
-                                        {...headerGroup.headers[0].getHeaderProps(
-                                            headerGroup.headers[0].getSortByToggleProps()
-                                        )}
-                                        style={{
-                                            position: "sticky",
-                                            left: 0,
-                                            background: "rgba(241, 241, 241, 1)",
-                                            zIndex: 2
-                                        }}
-                                    >
-                                        {headerGroup.headers[0].render("Header")}
-                                        <span>
-                                            {(() => {
-                                                const column = headerGroup.headers[0];
-                                                if (!column.isSorted)
-                                                    return (
-                                                        <Box sx={{ ml: 1, display: "inline" }}>
-                                                            <SwapVertIcon />
-                                                        </Box>
-                                                    );
-                                                if (column.isSortedDesc)
-                                                    return <Box sx={{ ml: 1, display: "inline" }}>{"\u{25BC}"}</Box>;
-                                                return <Box sx={{ ml: 1, display: "inline" }}>{"\u{25B2}"}</Box>;
-                                            })()}
-                                        </span>
-                                    </th>
-                                    {headerGroup.headers
-                                        .filter((_, index) => visibleColumnIndices.includes(index))
-                                        .map((column) => (
-                                            <th {...column.getHeaderProps(column.getSortByToggleProps())} key={column}>
+                            {headerGroups.map((headerGroup) => {
+                                const headerGroupProps = headerGroup.getHeaderGroupProps();
+                                return (
+                                    <tr {...headerGroupProps} key={`header-${headerGroupProps.key}`}>
+                                        <th
+                                            {...headerGroup.headers[0].getHeaderProps(
+                                                headerGroup.headers[0].getSortByToggleProps()
+                                            )}
+                                            style={{
+                                                position: "sticky",
+                                                left: 0,
+                                                background: "rgba(241, 241, 241, 1)",
+                                                zIndex: 2
+                                            }}
+                                        >
+                                            {headerGroup.headers[0].render("Header")}
+                                            <span>
                                                 {(() => {
-                                                    const headerText = column.render("Header");
-                                                    if (typeof headerText === "string" && headerText.includes(":")) {
-                                                        const [beforeColon, afterColon] = headerText.split(":");
+                                                    const column = headerGroup.headers[0];
+                                                    if (!column.isSorted)
                                                         return (
-                                                            <>
-                                                                <div>
-                                                                    <strong>{beforeColon}</strong>
-                                                                </div>
-                                                                <span>{afterColon.trim()}</span>
-                                                            </>
+                                                            <Box sx={{ ml: 1, display: "inline" }}>
+                                                                <SwapVertIcon />
+                                                            </Box>
                                                         );
-                                                    }
-                                                    return headerText;
+                                                    if (column.isSortedDesc)
+                                                        return (
+                                                            <Box sx={{ ml: 1, display: "inline" }}>{"\u{25BC}"}</Box>
+                                                        );
+                                                    return <Box sx={{ ml: 1, display: "inline" }}>{"\u{25B2}"}</Box>;
                                                 })()}
-                                                <span>
+                                            </span>
+                                        </th>
+                                        {headerGroup.headers
+                                            .filter((_, index) => visibleColumnIndices.includes(index))
+                                            .map((column) => (
+                                                <th
+                                                    {...column.getHeaderProps(column.getSortByToggleProps())}
+                                                    key={column.id || column.Header}
+                                                >
                                                     {(() => {
-                                                        if (!column.isSorted)
+                                                        const headerText = column.render("Header");
+                                                        if (
+                                                            typeof headerText === "string" &&
+                                                            headerText.includes(":")
+                                                        ) {
+                                                            const [beforeColon, afterColon] = headerText.split(":");
                                                             return (
-                                                                <Box sx={{ ml: 1, display: "inline" }}>
-                                                                    <SwapVertIcon />
-                                                                </Box>
+                                                                <>
+                                                                    <div>
+                                                                        <strong>{beforeColon}</strong>
+                                                                    </div>
+                                                                    <span>{afterColon.trim()}</span>
+                                                                </>
                                                             );
-                                                        if (column.isSortedDesc)
-                                                            return (
-                                                                <Box sx={{ ml: 1, display: "inline" }}>
-                                                                    {"\u{25BC}"}
-                                                                </Box>
-                                                            );
-                                                        return (
-                                                            <Box sx={{ ml: 1, display: "inline" }}>{"\u{25B2}"}</Box>
-                                                        );
+                                                        }
+                                                        return headerText;
                                                     })()}
-                                                </span>
-                                            </th>
-                                        ))}
-                                </tr>
-                            ))}
+                                                    <span>
+                                                        {(() => {
+                                                            if (!column.isSorted)
+                                                                return (
+                                                                    <Box sx={{ ml: 1, display: "inline" }}>
+                                                                        <SwapVertIcon />
+                                                                    </Box>
+                                                                );
+                                                            if (column.isSortedDesc)
+                                                                return (
+                                                                    <Box sx={{ ml: 1, display: "inline" }}>
+                                                                        {"\u{25BC}"}
+                                                                    </Box>
+                                                                );
+                                                            return (
+                                                                <Box sx={{ ml: 1, display: "inline" }}>
+                                                                    {"\u{25B2}"}
+                                                                </Box>
+                                                            );
+                                                        })()}
+                                                    </span>
+                                                </th>
+                                            ))}
+                                    </tr>
+                                );
+                            })}
                         </thead>
                         <tbody {...getTableBodyProps()}>
-                            {page.map((row, i) => {
+                            {page.map((row) => {
                                 prepareRow(row);
+                                const rowProps = row.getRowProps();
                                 return (
-                                    <tr {...row.getRowProps()} key={row}>
+                                    <tr {...rowProps} key={`row-${row.id}`}>
                                         <td
                                             {...row.cells[0].getCellProps()}
                                             style={{
@@ -270,10 +284,10 @@ function Table({ programName, columns, data }) {
                                         </td>
                                         {row.cells
                                             .filter((_, index) => visibleColumnIndices.includes(index))
-                                            .map((cell, j) => (
+                                            .map((cell, cellIndex) => (
                                                 <td
-                                                    key={`cell${j + 1}`}
-                                                    className={`cell${j + 1}`}
+                                                    key={`${row.id}-${cell.column.id}`}
+                                                    className={`cell${cellIndex + 1}`}
                                                     {...cell.getCellProps()}
                                                     style={{ width: "100%", whiteSpace: "nowrap" }}
                                                 >
@@ -329,7 +343,7 @@ function Table({ programName, columns, data }) {
                                 }}
                             >
                                 {[10, 25, 40, 51].map((size) => (
-                                    <option key={size} value={size}>
+                                    <option key={`size-${size}`} value={size}>
                                         Show {size}
                                     </option>
                                 ))}


### PR DESCRIPTION
This PR addresses issues #341, #344, and #345, which include the changes we plan to release this week.

## Changes Included in the PR:
1. A more robust loading strategy has been added to address the map tip rendering issue Jonathan mentioned during Monday's meeting.
2. All instances of 'grey' on the website have been updated to 'gray' to align with US spelling conventions.
3. The comma separator for the EQIP & CSP selector has been replaced with a delimiter. Please note that the map does not currently support multi-selection until the API is updated in the development environment. Once updated, the changes should reflect automatically. In the meantime, you can verify the queries using the Network console.

## How to Test

1. Navigate to the EQIP & CSP Total page, and verify that the map tips load correctly.  

2. Open the **Network** console and select multiple practices from the selector. You should observe:  
   - The map tips load correctly.  
   - The query is processed using `|` to separate practices. The comma inside the practice names is encoded as usual. For exaample:  
     ```
     https://policydesignlab-dev.ncsa.illinois.edu/pdl/titles/title-ii/programs/csp/state-distribution?practice_code=2%20-%20Non-Irrigated%20Cropland|1|3%20-%20Soil%20health%20rotation%2C%20No%20till
     ```  

     ![Screenshot 2024-12-05 at 12 07 04 PM](https://github.com/user-attachments/assets/278b2d82-b7dd-484c-8a22-8e6c829aa994)  

3. All instances of the word 'grey' throughout the site have been updated to 'gray.'  

4. For the map tip loading, you can test under different monitor setups or network conditions.  