### PR TITLE
Update Title II CRP years to 2014-2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Support title II year range change [#371](https://github.com/policy-design-lab/pdl-frontend/issues/371)
+- Update Title II CRP subpage to 2014-2023 [#380](https://github.com/policy-design-lab/pdl-frontend/issues/380)
 
 ## [1.8.0] - 2025-03-10
 

--- a/src/components/crp/CategoryMap.tsx
+++ b/src/components/crp/CategoryMap.tsx
@@ -238,7 +238,6 @@ const CategoryMap = ({
         }
         return null;
     });
-    const years = "2014-2023";
     const maxValue = Math.max(...quantizeArray);
     const mapColor = ["#F0F9E8", "#BAE4BC", "#7BCCC4", "#43A2CA", "#0868AC"];
     const customScale = legendConfig[category === "Grassland" ? "Grassland-CRP" : category];
@@ -251,7 +250,7 @@ const CategoryMap = ({
                     {maxValue !== 0 ? (
                         <DrawLegend
                             colorScale={colorScale}
-                            title={titleElement(category, years)}
+                            title={titleElement(category, year)}
                             programData={quantizeArray}
                             prepColor={mapColor}
                             isRatio={false}
@@ -260,10 +259,10 @@ const CategoryMap = ({
                         />
                     ) : (
                         <div>
-                            {titleElement(category, years)}
+                            {titleElement(category, year)}
                             <Box display="flex" justifyContent="center">
                                 <Typography sx={{ color: "#CCC", fontWeight: 700 }}>
-                                    {category} data in {years} is unavailable for all states.
+                                    {category} data in {year} is unavailable for all states.
                                 </Typography>
                             </Box>
                         </div>

--- a/src/components/crp/CategoryMap.tsx
+++ b/src/components/crp/CategoryMap.tsx
@@ -238,7 +238,7 @@ const CategoryMap = ({
         }
         return null;
     });
-    const years = "2018-2022";
+    const years = "2014-2023";
     const maxValue = Math.max(...quantizeArray);
     const mapColor = ["#F0F9E8", "#BAE4BC", "#7BCCC4", "#43A2CA", "#0868AC"];
     const customScale = legendConfig[category === "Grassland" ? "Grassland-CRP" : category];


### PR DESCRIPTION
In the last frontend change, CRP did not get updated to 2014-2023. This PR makes up for that.

I also checked other subpages, those look fine.