### PR TITLE
#382: Bump the Ubuntu version for the Lint Github action to the latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on: [ push,pull_request ]
 jobs:
   build:
     name: Test Suite
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up Node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Support title II year range change [#371](https://github.com/policy-design-lab/pdl-frontend/issues/371)
 - Bump the Ubuntu version of the Lint Github action to latest [#382](https://github.com/policy-design-lab/pdl-frontend/issues/382)
+- Update rules for Danger Github action to eliminate unnecessary checks when PR is in draft status
 
 ## [1.8.0] - 2025-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Support title II year range change [#371](https://github.com/policy-design-lab/pdl-frontend/issues/371)
+- Bump the Ubuntu version of the Lint Github action to latest [#382](https://github.com/policy-design-lab/pdl-frontend/issues/382)
 
 ## [1.8.0] - 2025-03-10
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,33 +1,31 @@
-import { danger, warn, fail } from 'danger'
+import { danger, warn, fail } from "danger";
 
-const hasAppChanges = danger.git.modified_files.some(file => file.includes('src'))
-const hasChangelog = danger.git.modified_files.includes("CHANGELOG.md")
-const isDeclaredTrivial = (danger.github.pr.title + danger.github.pr.body).includes('#trivial') || !hasAppChanges
+const hasAppChanges = danger.git.modified_files.some((file) => file.includes("src"));
+const hasChangelog = danger.git.modified_files.includes("CHANGELOG.md");
+const isDeclaredTrivial = (danger.github.pr.title + danger.github.pr.body).includes("#trivial") || !hasAppChanges;
 
-//Make sure we add changelog
-if (!hasChangelog && !isDeclaredTrivial) {
-  warn("Please add a changelog entry for your changes.");
+if (danger.github.pr.title.includes("[WIP]")) {
+    warn("PR is classed as Work in Progress");
+} else {
+    //Make sure we add changelog
+    if (!hasChangelog && !isDeclaredTrivial) {
+        warn("Please add a changelog entry for your changes.");
+    }
+    //Mainly to encourage writing up some reasoning about the PR, rather than just leaving a title
+    if (danger.github.pr.body.length < 3) {
+        warn("Please add a detailed summary in the description.");
+    }
+    //Detect .eslintrc changes and set warnings
+    if (danger.git.modified_files.includes(".eslintrc")) {
+        warn(
+            "Changes were made to .eslintrc. Please ensure that you have notified the team to change the existing ESLint rule."
+        );
+    }
 }
-
-//Mainly to encourage writing up some reasoning about the PR, rather than just leaving a title
-if (danger.github.pr.body.length < 3) {
-    warn('Please add a detailed summary in the description.') 
-}
-
 //Temporary disable this since tasks like create new page may include more than 500 lines of code
 // if (git.lines_of_code > 500) {
-//     warn('This PR is too big! Consider breaking it down into smaller PRs.') 
+//     warn('This PR is too big! Consider breaking it down into smaller PRs.')
 // }
-
-//Make it more obvious that a PR is a work in progress and shouldn't be merged yet
-if (danger.github.pr.title.includes('[WIP]')) {
-    warn('PR is classed as Work in Progress') 
-}
-
-//Detect .eslintrc changes and set warnings
-if (danger.git.modified_files.includes('.eslintrc')) {
-  warn('Changes were made to .eslintrc. Please ensure that you have notified the team to change the existing ESLint rule.')
-}
 
 // In the future: make sure non-trivial amounts of code changes come with corresponding tests
 /*


### PR DESCRIPTION
This PR addresses issue #382. Currently, PRs are encountering canceled Lint GitHub Actions (appearing as failures in Actions) because GitHub is retiring Ubuntu 20.

This update bumps the Ubuntu version to the latest available, preventing this issue in future PRs. A successful run of the`Tests Suite` indicates that this PR is ready to be merged.

---
I also updated the Dangerfile to skip checks when a PR is in draft status (i.e., when "[WIP]" is in the PR title), so that no Danger warnings or errors are reported during trial runs.