### PR TITLE
#412, #410, #409, #408: Bug Fixes & Feature Development for Title I Page Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add the 'Download CSV' feature to all tables in Title I page [#412](https://github.com/policy-design-lab/pdl-frontend/issues/412)
 
 ### Changed
-- Changed the 'Total Count' variables in Title I page to be 'Average Recipient' variables[#410](https://github.com/policy-design-lab/pdl-frontend/issues/410)
+- Rounded all of the 'Payment' columns in Title I page to be integer value [#414](https://github.com/policy-design-lab/pdl-frontend/issues/414)
+- Changed the 'Total Count' variables in Title I page to be 'Average Recipient' variables [#410](https://github.com/policy-design-lab/pdl-frontend/issues/410)
 - Rounding the Base Acres columns in Title I page to integer [#409](https://github.com/policy-design-lab/pdl-frontend/issues/409)
 - Refactor SNAP map [#395](https://github.com/policy-design-lab/pdl-frontend/issues/395)
 - Update Title-1 map to use 2014 - 2023 data [#403](https://github.com/policy-design-lab/pdl-frontend/issues/403)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add the 'Download CSV' feature to all tables in Title I page [#412](https://github.com/policy-design-lab/pdl-frontend/issues/412)
+
 ### Changed
-- Refactor SNAP map. [#395](https://github.com/policy-design-lab/pdl-frontend/issues/395)
-- Update Title-1 map to use 2014 - 2023 data. [#403](https://github.com/policy-design-lab/pdl-frontend/issues/403)
+- Changed the 'Total Count' variables in Title I page to be 'Average Recipient' variables[#410](https://github.com/policy-design-lab/pdl-frontend/issues/410)
+- Rounding the Base Acres columns in Title I page to integer [#409](https://github.com/policy-design-lab/pdl-frontend/issues/409)
+- Refactor SNAP map [#395](https://github.com/policy-design-lab/pdl-frontend/issues/395)
+- Update Title-1 map to use 2014 - 2023 data [#403](https://github.com/policy-design-lab/pdl-frontend/issues/403)
 
 ### Fixed
+- Used rounding instead of truncating for all numbers that need a integer format [#408](https://github.com/policy-design-lab/pdl-frontend/issues/408)
 - Fixed the sorting function for all tables [#407](https://github.com/policy-design-lab/pdl-frontend/issues/407)
 
 ## [1.10.0] - 2025-07-09

--- a/src/components/acep/ACEPTable.tsx
+++ b/src/components/acep/ACEPTable.tsx
@@ -10,6 +10,7 @@ import {
     compareWithPercentSign
 } from "../shared/TableCompareFunctions";
 import "../../styles/table.css";
+import { formatCurrency } from "../shared/ConvertionFormats";
 
 function AcepProgramTable({
     tableTitle,
@@ -45,13 +46,9 @@ function AcepProgramTable({
             if (attr.includes("Percentage")) {
                 newRecord[attr] = `${value.toString()}%`;
             } else if (attr === "totalAreaInAcres" || attr === "totalContracts") {
-                newRecord[attr] = `${
-                    value.toLocaleString(undefined, { minimumFractionDigits: 2 }).toString().split(".")[0]
-                }`;
+                newRecord[attr] = `${formatCurrency(value, { minimumFractionDigits: 0 })}`;
             } else {
-                newRecord[attr] = `$${
-                    value.toLocaleString(undefined, { minimumFractionDigits: 2 }).toString().split(".")[0]
-                }`;
+                newRecord[attr] = formatCurrency(value, { minimumFractionDigits: 0 });
             }
         });
         resultData.push(newRecord);

--- a/src/components/acep/ACEPTable.tsx
+++ b/src/components/acep/ACEPTable.tsx
@@ -46,9 +46,9 @@ function AcepProgramTable({
             if (attr.includes("Percentage")) {
                 newRecord[attr] = `${value.toString()}%`;
             } else if (attr === "totalAreaInAcres" || attr === "totalContracts") {
-                newRecord[attr] = `${formatCurrency(value, { minimumFractionDigits: 0 })}`;
+                newRecord[attr] = `${formatCurrency(value, 0)}`;
             } else {
-                newRecord[attr] = formatCurrency(value, { minimumFractionDigits: 0 });
+                newRecord[attr] = formatCurrency(value, 0);
             }
         });
         resultData.push(newRecord);

--- a/src/components/acep/ACEPTotalTable.tsx
+++ b/src/components/acep/ACEPTotalTable.tsx
@@ -5,6 +5,7 @@ import Box from "@mui/material/Box";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import "../../styles/table.css";
 import { compareWithDollarSign, compareWithNumber } from "../shared/TableCompareFunctions";
+import { formatCurrency } from "../shared/ConvertionFormats";
 
 const Styles = styled.div`
     padding: 1rem;
@@ -150,12 +151,7 @@ function App({
         const newRecord = () => {
             return {
                 state: stateName,
-                rcppBenefit: `$${
-                    totalRcpp.totalPaymentInDollars
-                        .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                        .toString()
-                        .split(".")[0]
-                }`,
+                rcppBenefit: formatCurrency(totalRcpp.totalPaymentInDollars, { minimumFractionDigits: 0 }),
                 percentage: `${totalRcpp.totalPaymentInPercentageNationwide.toString()}%`,
                 noContract: `${totalRcpp.totalContracts
                     .toLocaleString(undefined, { minimumFractionDigits: 0 })

--- a/src/components/acep/ACEPTotalTable.tsx
+++ b/src/components/acep/ACEPTotalTable.tsx
@@ -5,7 +5,7 @@ import Box from "@mui/material/Box";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import "../../styles/table.css";
 import { compareWithDollarSign, compareWithNumber } from "../shared/TableCompareFunctions";
-import { formatCurrency } from "../shared/ConvertionFormats";
+import { formatCurrency, formatNumericValue } from "../shared/ConvertionFormats";
 
 const Styles = styled.div`
     padding: 1rem;
@@ -151,14 +151,10 @@ function App({
         const newRecord = () => {
             return {
                 state: stateName,
-                rcppBenefit: formatCurrency(totalRcpp.totalPaymentInDollars, { minimumFractionDigits: 0 }),
+                rcppBenefit: formatCurrency(totalRcpp.totalPaymentInDollars, 0),
                 percentage: `${totalRcpp.totalPaymentInPercentageNationwide.toString()}%`,
-                noContract: `${totalRcpp.totalContracts
-                    .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                    .toString()}`,
-                totAcre: `${totalRcpp.totalAreaInAcres
-                    .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                    .toString()}`
+                noContract: `${formatNumericValue(totalRcpp.totalContracts, 0)}`,
+                totAcre: `${formatNumericValue(totalRcpp.totalAreaInAcres, 0)}`
             };
         };
         rcppTableData.push(newRecord());

--- a/src/components/cropinsurance/CropInsuranceTable.tsx
+++ b/src/components/cropinsurance/CropInsuranceTable.tsx
@@ -10,7 +10,7 @@ import {
     compareWithPercentSign
 } from "../shared/TableCompareFunctions";
 import "../../styles/table.css";
-import { ShortFormat } from "../shared/ConvertionFormats";
+import { formatCurrency, ShortFormat } from "../shared/ConvertionFormats";
 
 function CropInsuranceProgramTable({
     tableTitle,
@@ -39,13 +39,9 @@ function CropInsuranceProgramTable({
             if (attr === "lossRatio") {
                 newRecord[attr] = `${ShortFormat((Number(value) * 100).toString(), undefined, 1)}%`;
             } else if (attr === "averageInsuredAreaInAcres" || attr === "totalPoliciesEarningPremium") {
-                newRecord[attr] = `${
-                    value.toLocaleString(undefined, { minimumFractionDigits: 2 }).toString().split(".")[0]
-                }`;
+                newRecord[attr] = formatCurrency(value, { minimumFractionDigits: 0 });
             } else {
-                newRecord[attr] = `$${
-                    value.toLocaleString(undefined, { minimumFractionDigits: 2 }).toString().split(".")[0]
-                }`;
+                newRecord[attr] = formatCurrency(value, { minimumFractionDigits: 0 });
             }
         });
         resultData.push(newRecord);

--- a/src/components/cropinsurance/CropInsuranceTable.tsx
+++ b/src/components/cropinsurance/CropInsuranceTable.tsx
@@ -39,9 +39,9 @@ function CropInsuranceProgramTable({
             if (attr === "lossRatio") {
                 newRecord[attr] = `${ShortFormat((Number(value) * 100).toString(), undefined, 1)}%`;
             } else if (attr === "averageInsuredAreaInAcres" || attr === "totalPoliciesEarningPremium") {
-                newRecord[attr] = formatCurrency(value, { minimumFractionDigits: 0 });
+                newRecord[attr] = formatCurrency(value, 0);
             } else {
-                newRecord[attr] = formatCurrency(value, { minimumFractionDigits: 0 });
+                newRecord[attr] = formatCurrency(value, 0);
             }
         });
         resultData.push(newRecord);

--- a/src/components/crp/CRPTotalTable.tsx
+++ b/src/components/crp/CRPTotalTable.tsx
@@ -155,13 +155,9 @@ function App({
                     .toLocaleString(undefined, { minimumFractionDigits: 2 })
                     .toString()}`,
                 percentage: `${totalCrp.totalPaymentInPercentageNationwide.toString()}%`,
-                noContract: `${totalCrp.totalContracts
-                    .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                    .toString()}`,
-                noFarm: `${totalCrp.totalFarms.toLocaleString(undefined, { minimumFractionDigits: 0 }).toString()}`,
-                totAcre: `${totalCrp.totalAreaInAcres
-                    .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                    .toString()}`
+                noContract: `${totalCrp.totalContracts.toLocaleString(undefined, 0).toString()}`,
+                noFarm: `${totalCrp.totalFarms.toLocaleString(undefined, 0).toString()}`,
+                totAcre: `${totalCrp.totalAreaInAcres.toLocaleString(undefined, 0).toString()}`
             };
         };
         crpTableData.push(newRecord());

--- a/src/components/crp/CategoryTable.tsx
+++ b/src/components/crp/CategoryTable.tsx
@@ -4,6 +4,7 @@ import { useTable, useSortBy } from "react-table";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import Box from "@mui/material/Box";
 import "../../styles/table.css";
+import { formatCurrency, formatNumericValue } from "../shared/ConvertionFormats";
 
 const Styles = styled.div`
     padding: 1rem;
@@ -173,15 +174,9 @@ function App({
         const newRecord = () => {
             return {
                 state: stateName,
-                categoryBenefit: `$${categoryCrp.totalPaymentInDollars
-                    .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                    .toString()}`,
-                categoryPercentage: `${categoryCrp.totalPaymentInPercentageWithinState
-                    .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                    .toString()}%`,
-                crpBenefit: `$${totalCrp.totalPaymentInDollars
-                    .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                    .toString()}`,
+                categoryBenefit: formatCurrency(categoryCrp.totalPaymentInDollars, 2),
+                categoryPercentage: `${formatNumericValue(categoryCrp.totalPaymentInPercentageWithinState, 2)}%`,
+                crpBenefit: formatCurrency(totalCrp.totalPaymentInDollars, 2),
                 percentage: `${categoryCrp.totalPaymentInPercentageNationwide.toString()}%`
             };
         };

--- a/src/components/hModel/CountyCommodityTable.tsx
+++ b/src/components/hModel/CountyCommodityTable.tsx
@@ -8,14 +8,13 @@ import MapIcon from "@mui/icons-material/Map";
 import {
     YearBreakdownData,
     CountyObject,
-    formatCurrency,
-    formatNumericValue,
     getCountyNameFromFips,
     generateTableTitle,
     generateCsvFilename,
     getTotalBaseAcres,
     formatCellValue
 } from "./utils";
+import { formatCurrency, formatNumericValue } from "../shared/ConvertionFormats";
 
 interface ExtendedYearBreakdownData extends YearBreakdownData {
     paymentRate?: number;

--- a/src/components/hModel/CountyCommodityTable.tsx
+++ b/src/components/hModel/CountyCommodityTable.tsx
@@ -980,8 +980,8 @@ const CountyCommodityTable: React.FC<CountyCommodityTableProps> = ({
                         const proposedRate = actualProposedBaseAcres > 0 ? proposedTotal / actualProposedBaseAcres : 0;
                         row.weightedAverageRate = proposedRate - currentRate;
                     } else if (totalBaseAcres > 0) {
-                        const precisedTotal = Math.round(aggTotal * 100) / 100;
-                        const precisedBaseAcres = Math.round(totalBaseAcres * 100) / 100;
+                        const precisedTotal = formatNumericValue(aggTotal);
+                        const precisedBaseAcres = formatNumericValue(totalBaseAcres);
                         row.weightedAverageRate = precisedTotal / precisedBaseAcres;
                     } else {
                         row.weightedAverageRate = 0;

--- a/src/components/hModel/utils.ts
+++ b/src/components/hModel/utils.ts
@@ -1,5 +1,5 @@
 import countyFipsMapping from "../../files/maps/fips_county_mapping.json";
-import { formatPaymentRateUnified } from "../shared/ConvertionFormats";
+import { formatCurrency, formatPaymentRate } from "../shared/ConvertionFormats";
 
 export interface YearBreakdownData {
     current?: string | number;
@@ -44,17 +44,6 @@ interface TableCell {
     value: string | number;
     render: (type: string) => string | number;
 }
-
-export const formatCurrency = (value: number, options = { minimumFractionDigits: 2 }): string => {
-    const roundedValue = Math.round(value * 100) / 100;
-    return `$${roundedValue.toLocaleString(undefined, options)}`;
-};
-
-export const formatPaymentRate = formatPaymentRateUnified;
-
-export const formatNumericValue = (value: number): number => {
-    return Math.round(value * 100) / 100;
-};
 
 export const getCountyNameFromFips = (countyFIPS: string): string => {
     return countyFipsMapping[countyFIPS] || "";

--- a/src/components/ira/IRADollarTable.tsx
+++ b/src/components/ira/IRADollarTable.tsx
@@ -100,7 +100,7 @@ function IRADollarTable({
         const newRecord = { state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === s)[0]] };
         Object.entries(hashmap[s]).forEach(([attr, value]) => {
             if (value) {
-                const formattedValue = formatCurrency(value, { minimumFractionDigits: 0 });
+                const formattedValue = formatCurrency(value, 0);
                 if (attr.includes("Dollar")) {
                     newRecord[attr] = `$${formattedValue}`;
                 } else {

--- a/src/components/ira/IRADollarTable.tsx
+++ b/src/components/ira/IRADollarTable.tsx
@@ -7,6 +7,7 @@ import { Grid, TableContainer, Typography, Box, Button } from "@mui/material";
 import { compareWithNumber, compareWithAlphabetic, compareWithDollarSign } from "../shared/TableCompareFunctions";
 import "../../styles/table.css";
 import getCSVData from "../shared/getCSVData";
+import { formatCurrency } from "../shared/ConvertionFormats";
 
 function IRADollarTable({
     tableTitle,
@@ -99,10 +100,7 @@ function IRADollarTable({
         const newRecord = { state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === s)[0]] };
         Object.entries(hashmap[s]).forEach(([attr, value]) => {
             if (value) {
-                const formattedValue = value
-                    .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                    .toString()
-                    .split(".")[0];
+                const formattedValue = formatCurrency(value, { minimumFractionDigits: 0 });
                 if (attr.includes("Dollar")) {
                     newRecord[attr] = `$${formattedValue}`;
                 } else {

--- a/src/components/ira/IRAPredictedDollarTable.tsx
+++ b/src/components/ira/IRAPredictedDollarTable.tsx
@@ -7,6 +7,7 @@ import { Grid, TableContainer, Typography, Box, Button } from "@mui/material";
 import { compareWithAlphabetic, compareWithDollarSign } from "../shared/TableCompareFunctions";
 import "../../styles/table.css";
 import getCSVData from "../shared/getCSVData";
+import { formatCurrency } from "../shared/ConvertionFormats";
 
 function IRAPredictedDollarTable({
     tableTitle,
@@ -89,10 +90,7 @@ function IRAPredictedDollarTable({
         const newRecord = { state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === s)[0]] };
         Object.entries(hashmap[s]).forEach(([attr, value]) => {
             if (value) {
-                const formattedValue = value
-                    .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                    .toString()
-                    .split(".")[0];
+                const formattedValue = formatCurrency(value, { minimumFractionDigits: 0 });
                 if (attr.includes("Dollar")) {
                     newRecord[attr] = `$${formattedValue}`;
                 } else {

--- a/src/components/ira/IRAPredictedDollarTable.tsx
+++ b/src/components/ira/IRAPredictedDollarTable.tsx
@@ -90,7 +90,7 @@ function IRAPredictedDollarTable({
         const newRecord = { state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === s)[0]] };
         Object.entries(hashmap[s]).forEach(([attr, value]) => {
             if (value) {
-                const formattedValue = formatCurrency(value, { minimumFractionDigits: 0 });
+                const formattedValue = formatCurrency(value, 0);
                 if (attr.includes("Dollar")) {
                     newRecord[attr] = `$${formattedValue}`;
                 } else {

--- a/src/components/rcpp/RCPPTotalTable.tsx
+++ b/src/components/rcpp/RCPPTotalTable.tsx
@@ -5,6 +5,7 @@ import Box from "@mui/material/Box";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import "../../styles/table.css";
 import { compareWithDollarSign, compareWithNumber } from "../shared/TableCompareFunctions";
+import { formatCurrency } from "../shared/ConvertionFormats";
 
 const Styles = styled.div`
     padding: 1rem;
@@ -150,12 +151,7 @@ function App({
         const newRecord = () => {
             return {
                 state: stateName,
-                rcppBenefit: `$${
-                    totalRcpp.totalPaymentInDollars
-                        .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                        .toString()
-                        .split(".")[0]
-                }`,
+                rcppBenefit: formatCurrency(totalRcpp.totalPaymentInDollars, { minimumFractionDigits: 0 }),
                 percentage: `${totalRcpp.totalPaymentInPercentageNationwide.toString()}%`,
                 noContract: `${totalRcpp.totalContracts
                     .toLocaleString(undefined, { minimumFractionDigits: 0 })

--- a/src/components/rcpp/RCPPTotalTable.tsx
+++ b/src/components/rcpp/RCPPTotalTable.tsx
@@ -151,14 +151,10 @@ function App({
         const newRecord = () => {
             return {
                 state: stateName,
-                rcppBenefit: formatCurrency(totalRcpp.totalPaymentInDollars, { minimumFractionDigits: 0 }),
+                rcppBenefit: formatCurrency(totalRcpp.totalPaymentInDollars, 0),
                 percentage: `${totalRcpp.totalPaymentInPercentageNationwide.toString()}%`,
-                noContract: `${totalRcpp.totalContracts
-                    .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                    .toString()}`,
-                totAcre: `${totalRcpp.totalAreaInAcres
-                    .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                    .toString()}`
+                noContract: `${totalRcpp.totalContracts.toLocaleString(undefined, 0).toString()}`,
+                totAcre: `${totalRcpp.totalAreaInAcres.toLocaleString(undefined, 0).toString()}`
             };
         };
         rcppTableData.push(newRecord());

--- a/src/components/shared/ConvertionFormats.tsx
+++ b/src/components/shared/ConvertionFormats.tsx
@@ -123,13 +123,13 @@ export const formatCurrency = (value: number, options = { minimumFractionDigits:
  * @param value
  * @param roundToInteger
  * @param returnAsString
- * @returns
+ * @returns Number always
  */
-export const formatNumericValue = (value: number, roundToInteger = false, returnAsString = true): string | number => {
+export const formatNumericValue = (value: number, roundToInteger = false): number => {
     if (roundToInteger) {
-        return returnAsString ? value.toFixed(0) : Math.round(value);
+        return Math.round(value);
     }
-    return returnAsString ? value.toFixed(2) : Number(value.toFixed(2));
+    return Number(value.toFixed(2));
 };
 
 export function ToPercentageString(value: string): string {

--- a/src/components/shared/ConvertionFormats.tsx
+++ b/src/components/shared/ConvertionFormats.tsx
@@ -100,12 +100,37 @@ export function ShortFormatPaymentRate(labelValue, isForDifference = false) {
     return result;
 }
 
-export function formatPaymentRateUnified(value: number, isForDifference = false): string {
+export function formatPaymentRate(value: number, isForDifference = false): string {
     if (value === 0 || value === null || value === undefined) return "";
     const decimalPlaces = isForDifference ? 2 : 2;
     const roundedValue = Math.round(value * 100) / 100;
     return roundedValue.toFixed(decimalPlaces);
 }
+
+/**
+ * Rounding a number to 2 decimal places then converting the result into a string with a dollar sign prefix
+ * @param value
+ * @param options
+ * @returns
+ */
+export const formatCurrency = (value: number, options = { minimumFractionDigits: 2 }): string => {
+    const roundedValue = Math.round(value * 100) / 100;
+    return `$${roundedValue.toLocaleString(undefined, options)}`;
+};
+
+/**
+ * Format numbers to either 0 or 2 decimal places while avoiding floating point errors
+ * @param value
+ * @param roundToInteger
+ * @param returnAsString
+ * @returns
+ */
+export const formatNumericValue = (value: number, roundToInteger = false, returnAsString = true): string | number => {
+    if (roundToInteger) {
+        return returnAsString ? value.toFixed(0) : Math.round(value);
+    }
+    return returnAsString ? value.toFixed(2) : Number(value.toFixed(2));
+};
 
 export function ToPercentageString(value: string): string {
     return `${parseFloat(value).toFixed(2)}%`;

--- a/src/components/shared/ConvertionFormats.tsx
+++ b/src/components/shared/ConvertionFormats.tsx
@@ -111,25 +111,26 @@ export function formatPaymentRate(value: number, isForDifference = false): strin
  * Rounding a number to 2 decimal places then converting the result into a string with a dollar sign prefix
  * @param value
  * @param options
- * @returns
+ * @returns string with a dollar sign prefix and the number rounded to the specified number of decimal places
  */
-export const formatCurrency = (value: number, options = { minimumFractionDigits: 2 }): string => {
-    const roundedValue = Math.round(value * 100) / 100;
-    return `$${roundedValue.toLocaleString(undefined, options)}`;
+export const formatCurrency = (value: number, decimals: 0 | 1 | 2 = 2): string => {
+    const factor = 10 ** decimals;
+    const roundedValue = Math.round(value * factor) / factor;
+    return `$${roundedValue.toLocaleString(undefined, {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals
+    })}`;
 };
 
 /**
- * Format numbers to either 0 or 2 decimal places while avoiding floating point errors
+ * Format numbers to 0,1 or 2 decimal places while avoiding floating point errors
  * @param value
  * @param roundToInteger
  * @param returnAsString
  * @returns Number always
  */
-export const formatNumericValue = (value: number, roundToInteger = false): number => {
-    if (roundToInteger) {
-        return Math.round(value);
-    }
-    return Number(value.toFixed(2));
+export const formatNumericValue = (value: number, decimals: 0 | 1 | 2 = 0): number => {
+    return Number(value.toFixed(decimals));
 };
 
 export function ToPercentageString(value: string): string {

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { CSVLink } from "react-csv";
 import { useTable, useSortBy, usePagination } from "react-table";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import { Grid, TableContainer, Typography, Box } from "@mui/material";
@@ -9,6 +10,8 @@ import {
     compareWithDollarSign,
     compareWithPercentSign
 } from "../shared/TableCompareFunctions";
+import { formatCurrency, formatNumericValue } from "../shared/ConvertionFormats";
+import getCSVData from "../shared/getCSVData";
 import "../../styles/table.css";
 
 function Title1ProgramTable({
@@ -38,24 +41,19 @@ function Title1ProgramTable({
                     totalPaymentInDollars: programData[0].totalPaymentInDollars,
                     totalPaymentInPercentageNationwide: programData[0].totalPaymentInPercentageNationwide,
                     totalPaymentInPercentageWithinState: programData[0].totalPaymentInPercentageWithinState,
-                    totalCounts: programData[0].totalCounts,
-                    totalCountsInPercentageNationwide: programData[0].totalCountsInPercentageNationwide,
                     averageRecipientCount: programData[0].averageRecipientCount,
                     averageRecipientCountInPercentageNationwide:
                         programData[0].averageRecipientCountInPercentageNationwide,
                     averageRecipientCountInPercentageWithinState:
-                        programData[0].averageRecipientCountInPercentageWithinState,
-                    totalCountsInPercentageWithinState: programData[0].totalCountsInPercentageWithinState
+                        programData[0].averageRecipientCountInPercentageWithinState
                 };
             } else {
                 // Subtitle D and E
                 hashmap[state] = {
                     totalPaymentInDollars: stateData.totalPaymentInDollars,
                     totalPaymentInPercentageNationwide: stateData.totalPaymentInPercentageNationwide,
-                    totalCounts: stateData.totalCounts,
                     averageRecipientCount: stateData.averageRecipientCount,
-                    averageRecipientCountInPercentageNationwide: stateData.averageRecipientCountInPercentageNationwide,
-                    totalCountsInPercentageNationwide: stateData.totalCountsInPercentageNationwide
+                    averageRecipientCountInPercentageNationwide: stateData.averageRecipientCountInPercentageNationwide
                 };
             }
         } else if (subtitle && program && subprogram) {
@@ -96,51 +94,30 @@ function Title1ProgramTable({
                     // SADA's program
                     return {
                         state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                        totalPaymentInDollars: `$${
-                            value.totalPaymentInDollars
-                                .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                                .toString()
-                                .split(".")[0]
-                        }`,
+                        totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, {
+                            minimumFractionDigits: 0
+                        }),
                         totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
                         totalPaymentInPercentageWithinState: `${value.totalPaymentInPercentageWithinState.toString()}%`,
-                        totalCounts: `${value.totalCounts
-                            .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                            .toString()}`,
                         averageRecipientCount: `${value.averageRecipientCount}`,
                         averageRecipientCountInPercentageNationwide: `${value.averageRecipientCountInPercentageNationwide.toString()}%`,
-                        totalCountsInPercentageNationwide: `${value.totalCountsInPercentageNationwide.toString()}%`,
-                        totalCountsInPercentageWithinState: `${value.totalCountsInPercentageWithinState.toString()}%`
+                        averageRecipientCountInPercentageWithinState: `${value.averageRecipientCountInPercentageWithinState.toString()}%`
                     };
                 }
                 return {
                     // subtitle D and E
                     state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                    totalPaymentInDollars: `$${
-                        value.totalPaymentInDollars
-                            .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                            .toString()
-                            .split(".")[0]
-                    }`,
+                    totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, { minimumFractionDigits: 0 }),
                     totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
-                    totalCounts: `${value.totalCounts
-                        .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                        .toString()}`,
                     averageRecipientCount: `${value.averageRecipientCount}`,
-                    averageRecipientCountInPercentageNationwide: `${value.averageRecipientCountInPercentageNationwide.toString()}%`,
-                    totalCountsInPercentageNationwide: `${value.totalCountsInPercentageNationwide.toString()}%`
+                    averageRecipientCountInPercentageNationwide: `${value.averageRecipientCountInPercentageNationwide.toString()}%`
                 };
             }
             // subtitle A
             if (subtitle && !program) {
                 return {
                     state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                    totalPaymentInDollars: `$${
-                        value.totalPaymentInDollars
-                            .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                            .toString()
-                            .split(".")[0]
-                    }`,
+                    totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, { minimumFractionDigits: 0 }),
                     totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`
                 };
             }
@@ -148,20 +125,11 @@ function Title1ProgramTable({
             if (subprogram) {
                 return {
                     state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                    totalPaymentInDollars: `$${
-                        value.totalPaymentInDollars
-                            .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                            .toString()
-                            .split(".")[0]
-                    }`,
+                    totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, { minimumFractionDigits: 0 }),
                     totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
                     totalPaymentInPercentageWithinState: `${value.totalPaymentInPercentageWithinState.toString()}%`,
                     averageAreaInAcres:
-                        value.averageAreaInAcres === 0
-                            ? "0"
-                            : `${value.averageAreaInAcres
-                                  .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                                  .toString()}`,
+                        value.averageAreaInAcres === 0 ? "0" : `${formatNumericValue(value.averageAreaInAcres, true)}`,
                     averageRecipientCount:
                         value.averageRecipientCount === 0
                             ? "0"
@@ -174,19 +142,12 @@ function Title1ProgramTable({
             return value.totalPaymentInDollars !== undefined
                 ? {
                       state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                      totalPaymentInDollars: `$${
-                          value.totalPaymentInDollars
-                              .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                              .toString()
-                              .split(".")[0]
-                      }`,
+                      totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, { minimumFractionDigits: 0 }),
                       totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
                       averageAreaInAcres:
                           value.averageAreaInAcres === 0
                               ? "0"
-                              : `${value.averageAreaInAcres
-                                    .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                                    .toString()}`,
+                              : `${formatNumericValue(value.averageAreaInAcres, true)}`,
                       averageRecipientCount:
                           value.averageRecipientCount === 0
                               ? "0"
@@ -258,7 +219,7 @@ function Title1ProgramTable({
                           sortType: compareWithNumber
                       },
                       {
-                          Header: "AVG. AVG. TOTAL RECIPIENTS",
+                          Header: "AVG. AVG. AVG. RECIPIENTS",
                           accessor: "averageRecipientCount",
                           sortType: compareWithNumber
                       }
@@ -289,7 +250,7 @@ function Title1ProgramTable({
                           sortType: compareWithNumber
                       },
                       {
-                          Header: "AVG. TOTAL RECIPIENTS",
+                          Header: "AVG. AVG. RECIPIENTS",
                           accessor: "averageRecipientCount",
                           sortType: compareWithNumber
                       }
@@ -322,18 +283,18 @@ function Title1ProgramTable({
                           sortType: compareWithPercentSign
                       },
                       {
-                          Header: "TOTAL RECIPIENTS",
-                          accessor: "totalCounts",
+                          Header: "AVG. RECIPIENTS",
+                          accessor: "averageRecipientCount",
                           sortType: compareWithNumber
                       },
                       {
-                          Header: "TOTAL RECIPIENTS PCT. NATIONWIDE",
-                          accessor: "totalCountsInPercentageNationwide",
+                          Header: "AVG. RECIPIENTS PCT. NATIONWIDE",
+                          accessor: "averageRecipientCountInPercentageNationwide",
                           sortType: compareWithNumber
                       },
                       {
-                          Header: "TOTAL RECIPIENTS COUNT PCT. WITHIN STATE",
-                          accessor: "totalCountsInPercentageWithinState",
+                          Header: "AVG. RECIPIENTS PCT. WITHIN STATE",
+                          accessor: "averageRecipientCountInPercentageWithinState",
                           sortType: compareWithNumber
                       }
                   ],
@@ -358,13 +319,13 @@ function Title1ProgramTable({
                           sortType: compareWithPercentSign
                       },
                       {
-                          Header: "TOTAL RECIPIENTS",
-                          accessor: "totalCounts",
+                          Header: "AVG. RECIPIENTS",
+                          accessor: "averageRecipientCount",
                           sortType: compareWithNumber
                       },
                       {
-                          Header: "TOTAL RECIPIENTS PCT. NATIONWIDE",
-                          accessor: "totalCountsInPercentageNationwide",
+                          Header: "AVG. RECIPIENTS PCT. NATIONWIDE",
+                          accessor: "averageRecipientCountInPercentageNationwide",
                           sortType: compareWithNumber
                       }
                   ],
@@ -478,6 +439,18 @@ function Title1ProgramTable({
                           margin-top: 8px;
                       }
                   }
+
+                  .downloadbtn {
+                      background-color: rgba(47, 113, 100, 1);
+                      padding: 8px 16px;
+                      border-radius: 4px;
+                      color: #fff;
+                      text-decoration: none;
+                      display: block;
+                      cursor: pointer;
+                      margin-bottom: 1em;
+                      text-align: center;
+                  }
               `
             : styled.div`
                   padding: 0;
@@ -563,6 +536,18 @@ function Title1ProgramTable({
                           margin-top: 8px;
                       }
                   }
+
+                  .downloadbtn {
+                      background-color: rgba(47, 113, 100, 1);
+                      padding: 8px 16px;
+                      border-radius: 4px;
+                      color: #fff;
+                      text-decoration: none;
+                      display: block;
+                      cursor: pointer;
+                      margin-bottom: 1em;
+                      text-align: center;
+                  }
               `;
     return (
         <Box display="flex" justifyContent="center" sx={{ width: "100%" }}>
@@ -621,6 +606,7 @@ function Title1ProgramTable({
                             pageSize: 10,
                             pageIndex: 0
                         }}
+                        tableTitle={tableTitle}
                     />
                 </TableContainer>
             </Styles>
@@ -629,7 +615,7 @@ function Title1ProgramTable({
 }
 
 // eslint-disable-next-line
-function Table({ columns, data, initialState }: { columns: any; data: any; initialState: any }) {
+function Table({ columns, data, initialState, tableTitle }: { columns: any; data: any; initialState: any; tableTitle: string }) {
     const {
         getTableProps,
         getTableBodyProps,
@@ -655,8 +641,14 @@ function Table({ columns, data, initialState }: { columns: any; data: any; initi
         useSortBy,
         usePagination
     );
+    const fileName = `${tableTitle.replace(/\s+/g, "-").toLowerCase()}-data.csv`;
     return (
         <div style={{ width: "100%" }}>
+            {data && data.length > 0 && (
+                <CSVLink className="downloadbtn" filename={fileName} data={getCSVData(headerGroups, data)}>
+                    Export This Table to CSV
+                </CSVLink>
+            )}
             <table {...getTableProps()} style={{ width: "100%", tableLayout: "fixed" }}>
                 <thead>
                     {headerGroups.map((headerGroup) => (

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -94,9 +94,7 @@ function Title1ProgramTable({
                     // SADA's program
                     return {
                         state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                        totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, {
-                            minimumFractionDigits: 0
-                        }),
+                        totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, 0),
                         totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
                         totalPaymentInPercentageWithinState: `${value.totalPaymentInPercentageWithinState.toString()}%`,
                         averageRecipientCount: `${value.averageRecipientCount}`,
@@ -107,7 +105,7 @@ function Title1ProgramTable({
                 return {
                     // subtitle D and E
                     state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                    totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, { minimumFractionDigits: 0 }),
+                    totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, 0),
                     totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
                     averageRecipientCount: `${value.averageRecipientCount}`,
                     averageRecipientCountInPercentageNationwide: `${value.averageRecipientCountInPercentageNationwide.toString()}%`
@@ -117,7 +115,7 @@ function Title1ProgramTable({
             if (subtitle && !program) {
                 return {
                     state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                    totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, { minimumFractionDigits: 0 }),
+                    totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, 0),
                     totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`
                 };
             }
@@ -125,35 +123,29 @@ function Title1ProgramTable({
             if (subprogram) {
                 return {
                     state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                    totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, { minimumFractionDigits: 0 }),
+                    totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, 0),
                     totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
                     totalPaymentInPercentageWithinState: `${value.totalPaymentInPercentageWithinState.toString()}%`,
                     averageAreaInAcres:
-                        value.averageAreaInAcres === 0 ? "0" : `${formatNumericValue(value.averageAreaInAcres, true)}`,
+                        value.averageAreaInAcres === 0 ? "0" : `${formatNumericValue(value.averageAreaInAcres, 0)}`,
                     averageRecipientCount:
                         value.averageRecipientCount === 0
                             ? "0"
-                            : `${value.averageRecipientCount
-                                  .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                                  .toString()}`
+                            : `${formatNumericValue(value.averageRecipientCount, 0)}`
                 };
             }
             // ARC & PLC
             return value.totalPaymentInDollars !== undefined
                 ? {
                       state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
-                      totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, { minimumFractionDigits: 0 }),
+                      totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, 0),
                       totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
                       averageAreaInAcres:
-                          value.averageAreaInAcres === 0
-                              ? "0"
-                              : `${formatNumericValue(value.averageAreaInAcres, true)}`,
+                          value.averageAreaInAcres === 0 ? "0" : `${formatNumericValue(value.averageAreaInAcres, 0)}`,
                       averageRecipientCount:
                           value.averageRecipientCount === 0
                               ? "0"
-                              : `${value.averageRecipientCount
-                                    .toLocaleString(undefined, { minimumFractionDigits: 0 })
-                                    .toString()}`
+                              : `${formatNumericValue(value.averageRecipientCount, 0)}`
                   }
                 : {
                       state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
@@ -615,7 +607,17 @@ function Title1ProgramTable({
 }
 
 // eslint-disable-next-line
-function Table({ columns, data, initialState, tableTitle }: { columns: any; data: any; initialState: any; tableTitle: string }) {
+function Table({
+    columns,
+    data,
+    initialState,
+    tableTitle
+}: {
+    columns: any;
+    data: any;
+    initialState: any;
+    tableTitle: string;
+}) {
     const {
         getTableProps,
         getTableBodyProps,

--- a/src/components/title1/Title1TotalTable.tsx
+++ b/src/components/title1/Title1TotalTable.tsx
@@ -129,7 +129,13 @@ function Table({ columns, data, tableTitle }: { columns: any; data: any; tableTi
                                         }
                                     })}
                                 >
-                                    <Box sx={{ display: "flex", alignItems: "center" }}>
+                                    <Box
+                                        sx={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            justifyContent: column.align === "right" ? "flex-end" : "flex-start"
+                                        }}
+                                    >
                                         {column.render("Header")}
                                         <div>
                                             {/* eslint-disable-next-line no-nested-ternary */}
@@ -269,6 +275,7 @@ function Title1TotalTable({
             {
                 Header: "TOTAL TITLE I BENEFITS",
                 accessor: "benefit",
+                align: "right",
                 sortType: compareWithDollarSign,
                 Cell: ({ value }: any) => <div style={{ textAlign: "right" }}>{value}</div>
             }

--- a/src/components/title1/Title1TotalTable.tsx
+++ b/src/components/title1/Title1TotalTable.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import styled from "styled-components";
+import { CSVLink } from "react-csv";
 import { useTable, useSortBy, usePagination } from "react-table";
 import Box from "@mui/material/Box";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import "../../styles/table.css";
 import { Typography, Grid, TableContainer } from "@mui/material";
 import { compareWithDollarSign } from "../shared/TableCompareFunctions";
+import { formatCurrency } from "../shared/ConvertionFormats";
+import getCSVData from "../shared/getCSVData";
 
 const Styles = styled.div`
     padding: 0;
@@ -62,9 +65,21 @@ const Styles = styled.div`
             margin-top: 1.5em;
         }
     }
+
+    .downloadbtn {
+        background-color: rgba(47, 113, 100, 1);
+        padding: 8px 16px;
+        border-radius: 4px;
+        color: #fff;
+        text-decoration: none;
+        display: block;
+        cursor: pointer;
+        margin-bottom: 1em;
+        text-align: center;
+    }
 `;
 
-function Table({ columns, data }: { columns: any; data: any }) {
+function Table({ columns, data, tableTitle }: { columns: any; data: any; tableTitle: string }) {
     const {
         getTableProps,
         getTableBodyProps,
@@ -90,9 +105,15 @@ function Table({ columns, data }: { columns: any; data: any }) {
         useSortBy,
         usePagination
     );
+    const fileName = `${tableTitle.replace(/\s+/g, "-").toLowerCase()}-data.csv`;
 
     return (
         <div style={{ width: "100%" }}>
+            {data && data.length > 0 && (
+                <CSVLink className="downloadbtn" filename={fileName} data={getCSVData(headerGroups, data)}>
+                    Export This Table to CSV
+                </CSVLink>
+            )}
             <table {...getTableProps()} style={{ width: "100%", tableLayout: "fixed" }}>
                 <thead>
                     {headerGroups.map((headerGroup) => (
@@ -234,9 +255,7 @@ function Title1TotalTable({
         });
         tableData.push({
             state: stateName,
-            benefit: `$${
-                totalRcpp.totalPaymentInDollars.toLocaleString(undefined, { minimumFractionDigits: 2 }).split(".")[0]
-            }`
+            benefit: formatCurrency(totalRcpp.totalPaymentInDollars, { minimumFractionDigits: 0 })
         });
     });
 
@@ -286,7 +305,7 @@ function Title1TotalTable({
                     </Grid>
                 </Grid>
                 <TableContainer sx={{ width: "100%" }}>
-                    <Table columns={columns} data={tableData} />
+                    <Table columns={columns} data={tableData} tableTitle={TableTitle} />
                 </TableContainer>
             </Styles>
         </Box>

--- a/src/components/title1/Title1TotalTable.tsx
+++ b/src/components/title1/Title1TotalTable.tsx
@@ -252,7 +252,7 @@ function Title1TotalTable({
     const tableData: any[] = [];
 
     statePerformance[year].forEach((value) => {
-        const totalRcpp = value;
+        const totalTitle1 = value;
         let stateName;
         stateCodes.forEach((sValue) => {
             if (sValue.code.toUpperCase() === value.state.toUpperCase()) {
@@ -261,7 +261,7 @@ function Title1TotalTable({
         });
         tableData.push({
             state: stateName,
-            benefit: formatCurrency(totalRcpp.totalPaymentInDollars, { minimumFractionDigits: 0 })
+            benefit: formatCurrency(totalTitle1.totalPaymentInDollars, 0)
         });
     });
 

--- a/src/components/title2/Title2TotalTable.tsx
+++ b/src/components/title2/Title2TotalTable.tsx
@@ -6,6 +6,7 @@ import SwapVertIcon from "@mui/icons-material/SwapVert";
 import "../../styles/table.css";
 import { Typography, Grid, TableContainer } from "@mui/material";
 import { compareWithDollarSign } from "../shared/TableCompareFunctions";
+import { formatCurrency } from "../shared/ConvertionFormats";
 
 const Styles = styled.div`
     padding: 0;
@@ -234,9 +235,7 @@ function Title2TotalTable({
         });
         rcppTableData.push({
             state: stateName,
-            rcppBenefit: `$${
-                totalRcpp.totalPaymentInDollars.toLocaleString(undefined, { minimumFractionDigits: 2 }).split(".")[0]
-            }`
+            rcppBenefit: formatCurrency(totalRcpp.totalPaymentInDollars, { minimumFractionDigits: 0 })
         });
     });
 

--- a/src/components/title2/Title2TotalTable.tsx
+++ b/src/components/title2/Title2TotalTable.tsx
@@ -241,7 +241,7 @@ function Title2TotalTable({
         });
         rcppTableData.push({
             state: stateName,
-            rcppBenefit: formatCurrency(totalRcpp.totalPaymentInDollars, { minimumFractionDigits: 0 })
+            rcppBenefit: formatCurrency(totalRcpp.totalPaymentInDollars, 0)
         });
     });
 

--- a/src/components/title2/Title2TotalTable.tsx
+++ b/src/components/title2/Title2TotalTable.tsx
@@ -109,7 +109,13 @@ function Table({ columns, data }: { columns: any; data: any }) {
                                         }
                                     })}
                                 >
-                                    <Box sx={{ display: "flex", alignItems: "center" }}>
+                                    <Box
+                                        sx={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            justifyContent: column.align === "right" ? "flex-end" : "flex-start"
+                                        }}
+                                    >
                                         {column.render("Header")}
                                         <div>
                                             {/* eslint-disable-next-line no-nested-ternary */}
@@ -249,6 +255,7 @@ function Title2TotalTable({
             {
                 Header: "TOTAL TITLE II BENEFITS",
                 accessor: "rcppBenefit",
+                align: "right",
                 sortType: compareWithDollarSign,
                 Cell: ({ value }: any) => <div style={{ textAlign: "right" }}>{value}</div>
             }

--- a/src/pages/ACEPPage.tsx
+++ b/src/pages/ACEPPage.tsx
@@ -10,6 +10,7 @@ import { convertAllState, getJsonDataFromUrl } from "../utils/apiutil";
 import NavSearchBar from "../components/shared/NavSearchBar";
 import DataTable from "../components/acep/ACEPTotalTable";
 import "../styles/subpage.css";
+import { formatCurrency } from "../components/shared/ConvertionFormats";
 
 export default function ACEPPage(): JSX.Element {
     const year = "2014-2023";
@@ -138,15 +139,7 @@ export default function ACEPPage(): JSX.Element {
                             <Box display="flex" justifyContent="center">
                                 <Typography variant="h6" sx={{ my: 2 }}>
                                     Total Benefits ({year}):
-                                    <strong>
-                                        $
-                                        {
-                                            totalAcep
-                                                .toLocaleString(undefined, { minimumFractionDigits: 2 })
-                                                .toString()
-                                                .split(".")[0]
-                                        }
-                                    </strong>
+                                    <strong>{formatCurrency(totalAcep, { minimumFractionDigits: 0 })}</strong>
                                 </Typography>
                             </Box>
                         </Box>

--- a/src/pages/ACEPPage.tsx
+++ b/src/pages/ACEPPage.tsx
@@ -139,7 +139,7 @@ export default function ACEPPage(): JSX.Element {
                             <Box display="flex" justifyContent="center">
                                 <Typography variant="h6" sx={{ my: 2 }}>
                                     Total Benefits ({year}):
-                                    <strong>{formatCurrency(totalAcep, { minimumFractionDigits: 0 })}</strong>
+                                    <strong>{formatCurrency(totalAcep, 0)}</strong>
                                 </Typography>
                             </Box>
                         </Box>

--- a/src/pages/RCPPPage.tsx
+++ b/src/pages/RCPPPage.tsx
@@ -8,6 +8,7 @@ import RCPPTotalMap from "../components/rcpp/RCPPTotalMap";
 import { config } from "../app.config";
 import { convertAllState, getJsonDataFromUrl } from "../utils/apiutil";
 import NavSearchBar from "../components/shared/NavSearchBar";
+import { formatCurrency } from "../components/shared/ConvertionFormats";
 
 export default function RCPPPage(): JSX.Element {
     const year = "2014-2023";
@@ -61,9 +62,7 @@ export default function RCPPPage(): JSX.Element {
         totalContracts = cur1.totalContracts;
         totalAreaInAcres = cur1.totalAreaInAcres;
         setZeroCategories(zeroCategory);
-        setTotalBenefit(
-            totalRCPPPaymentInDollars.toLocaleString(undefined, { minimumFractionDigits: 2 }).toString().split(".")[0]
-        );
+        setTotalBenefit(formatCurrency(totalRCPPPaymentInDollars, { minimumFractionDigits: 0 }));
     };
 
     return (

--- a/src/pages/RCPPPage.tsx
+++ b/src/pages/RCPPPage.tsx
@@ -62,7 +62,7 @@ export default function RCPPPage(): JSX.Element {
         totalContracts = cur1.totalContracts;
         totalAreaInAcres = cur1.totalAreaInAcres;
         setZeroCategories(zeroCategory);
-        setTotalBenefit(formatCurrency(totalRCPPPaymentInDollars, { minimumFractionDigits: 0 }));
+        setTotalBenefit(formatCurrency(totalRCPPPaymentInDollars, 0));
     };
 
     return (


### PR DESCRIPTION
This PR includes all updates needed for the upcoming Title I release, covering issues #408, #409, #410, and #412. The changes have been deployed to the dev environment.

For the rounding issue in #408, I also reviewed and updated similar tables across the website. You can validate these changes on pages like ACEP and RCPP under Title II.

## How to Test
1. Navigate to the Title I page. You should see an "Export Table to CSV" button for all tables. Click this button to download the table as a CSV file:
<img width="1163" height="372" alt="Screenshot 2025-07-29 at 6 12 44 PM" src="https://github.com/user-attachments/assets/0f5cdeeb-08f3-4305-a2a4-6cd0c8956bf4" />

2. Verify that all Subtitle D & E tables have replaced the "Total Count" variable with "Avg Recipients".

3. Confirm that all tables are rounding values correctly instead of truncating. Also, verify that all Base Acres values are now rounded to the nearest integer.
