### PR TITLE
Added commas to integer columns in Title I & II; Fixed IRA dollar tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Add comma to separate integer columns in Title I [#418](https://github.com/policy-design-lab/pdl-frontend/issues/418)
+
 ## [1.11.0] - 2025-07-31
 
 ### Added

--- a/src/components/acep/ACEPTotalTable.tsx
+++ b/src/components/acep/ACEPTotalTable.tsx
@@ -153,8 +153,8 @@ function App({
                 state: stateName,
                 rcppBenefit: formatCurrency(totalRcpp.totalPaymentInDollars, 0),
                 percentage: `${totalRcpp.totalPaymentInPercentageNationwide.toString()}%`,
-                noContract: `${formatNumericValue(totalRcpp.totalContracts, 0)}`,
-                totAcre: `${formatNumericValue(totalRcpp.totalAreaInAcres, 0)}`
+                noContract: formatNumericValue(totalRcpp.totalContracts, 0),
+                totAcre: formatNumericValue(totalRcpp.totalAreaInAcres, 0)
             };
         };
         rcppTableData.push(newRecord());

--- a/src/components/ira/IRADollarTable.tsx
+++ b/src/components/ira/IRADollarTable.tsx
@@ -7,7 +7,7 @@ import { Grid, TableContainer, Typography, Box, Button } from "@mui/material";
 import { compareWithNumber, compareWithAlphabetic, compareWithDollarSign } from "../shared/TableCompareFunctions";
 import "../../styles/table.css";
 import getCSVData from "../shared/getCSVData";
-import { formatCurrency } from "../shared/ConvertionFormats";
+import { formatCurrency, formatNumericValue } from "../shared/ConvertionFormats";
 
 function IRADollarTable({
     tableTitle,
@@ -100,11 +100,10 @@ function IRADollarTable({
         const newRecord = { state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === s)[0]] };
         Object.entries(hashmap[s]).forEach(([attr, value]) => {
             if (value) {
-                const formattedValue = formatCurrency(value, 0);
                 if (attr.includes("Dollar")) {
-                    newRecord[attr] = `${formattedValue}`;
+                    newRecord[attr] = `${formatCurrency(value, 0)}`;
                 } else {
-                    newRecord[attr] = `${formattedValue}`;
+                    newRecord[attr] = `${formatNumericValue(value, 0)}`;
                 }
             } else {
                 newRecord[attr] = attr.includes("Dollar") ? "$0" : "0";

--- a/src/components/ira/IRADollarTable.tsx
+++ b/src/components/ira/IRADollarTable.tsx
@@ -102,7 +102,7 @@ function IRADollarTable({
             if (value) {
                 const formattedValue = formatCurrency(value, 0);
                 if (attr.includes("Dollar")) {
-                    newRecord[attr] = `$${formattedValue}`;
+                    newRecord[attr] = `${formattedValue}`;
                 } else {
                     newRecord[attr] = `${formattedValue}`;
                 }

--- a/src/components/shared/ConvertionFormats.tsx
+++ b/src/components/shared/ConvertionFormats.tsx
@@ -129,8 +129,9 @@ export const formatCurrency = (value: number, decimals: 0 | 1 | 2 = 2): string =
  * @param returnAsString
  * @returns Number always
  */
-export const formatNumericValue = (value: number, decimals: 0 | 1 | 2 = 0): number => {
-    return Number(value.toFixed(decimals));
+export const formatNumericValue = (value: number, decimals: 0 | 1 | 2 = 0): string => {
+    const rounded = value.toFixed(decimals);
+    return rounded.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 };
 
 export function ToPercentageString(value: string): string {

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -97,7 +97,7 @@ function Title1ProgramTable({
                         totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, 0),
                         totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
                         totalPaymentInPercentageWithinState: `${value.totalPaymentInPercentageWithinState.toString()}%`,
-                        averageRecipientCount: `${value.averageRecipientCount}`,
+                        averageRecipientCount: formatNumericValue(value.averageRecipientCount, 0),
                         averageRecipientCountInPercentageNationwide: `${value.averageRecipientCountInPercentageNationwide.toString()}%`,
                         averageRecipientCountInPercentageWithinState: `${value.averageRecipientCountInPercentageWithinState.toString()}%`
                     };
@@ -107,7 +107,7 @@ function Title1ProgramTable({
                     state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],
                     totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, 0),
                     totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
-                    averageRecipientCount: `${value.averageRecipientCount}`,
+                    averageRecipientCount: formatNumericValue(value.averageRecipientCount, 0),
                     averageRecipientCountInPercentageNationwide: `${value.averageRecipientCountInPercentageNationwide.toString()}%`
                 };
             }
@@ -127,11 +127,11 @@ function Title1ProgramTable({
                     totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
                     totalPaymentInPercentageWithinState: `${value.totalPaymentInPercentageWithinState.toString()}%`,
                     averageAreaInAcres:
-                        value.averageAreaInAcres === 0 ? "0" : `${formatNumericValue(value.averageAreaInAcres, 0)}`,
+                        value.averageAreaInAcres === 0 ? "0" : formatNumericValue(value.averageAreaInAcres, 0),
                     averageRecipientCount:
                         value.averageRecipientCount === 0
                             ? "0"
-                            : `${formatNumericValue(value.averageRecipientCount, 0)}`
+                            : formatNumericValue(value.averageRecipientCount, 0)
                 };
             }
             // ARC & PLC
@@ -141,11 +141,11 @@ function Title1ProgramTable({
                       totalPaymentInDollars: formatCurrency(value.totalPaymentInDollars, 0),
                       totalPaymentInPercentageNationwide: `${value.totalPaymentInPercentageNationwide.toString()}%`,
                       averageAreaInAcres:
-                          value.averageAreaInAcres === 0 ? "0" : `${formatNumericValue(value.averageAreaInAcres, 0)}`,
+                          value.averageAreaInAcres === 0 ? "0" : formatNumericValue(value.averageAreaInAcres, 0),
                       averageRecipientCount:
                           value.averageRecipientCount === 0
                               ? "0"
-                              : `${formatNumericValue(value.averageRecipientCount, 0)}`
+                              : formatNumericValue(value.averageRecipientCount, 0)
                   }
                 : {
                       state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -242,7 +242,7 @@ function Title1ProgramTable({
                           sortType: compareWithNumber
                       },
                       {
-                          Header: "AVG. AVG. RECIPIENTS",
+                          Header: "AVG. RECIPIENTS",
                           accessor: "averageRecipientCount",
                           sortType: compareWithNumber
                       }

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -211,7 +211,7 @@ function Title1ProgramTable({
                           sortType: compareWithNumber
                       },
                       {
-                          Header: "AVG. AVG. AVG. RECIPIENTS",
+                          Header: "AVG. RECIPIENTS",
                           accessor: "averageRecipientCount",
                           sortType: compareWithNumber
                       }

--- a/src/components/title1/Title1ProgramTable.tsx
+++ b/src/components/title1/Title1ProgramTable.tsx
@@ -129,9 +129,7 @@ function Title1ProgramTable({
                     averageAreaInAcres:
                         value.averageAreaInAcres === 0 ? "0" : formatNumericValue(value.averageAreaInAcres, 0),
                     averageRecipientCount:
-                        value.averageRecipientCount === 0
-                            ? "0"
-                            : formatNumericValue(value.averageRecipientCount, 0)
+                        value.averageRecipientCount === 0 ? "0" : formatNumericValue(value.averageRecipientCount, 0)
                 };
             }
             // ARC & PLC
@@ -143,9 +141,7 @@ function Title1ProgramTable({
                       averageAreaInAcres:
                           value.averageAreaInAcres === 0 ? "0" : formatNumericValue(value.averageAreaInAcres, 0),
                       averageRecipientCount:
-                          value.averageRecipientCount === 0
-                              ? "0"
-                              : formatNumericValue(value.averageRecipientCount, 0)
+                          value.averageRecipientCount === 0 ? "0" : formatNumericValue(value.averageRecipientCount, 0)
                   }
                 : {
                       state: stateCodes[Object.keys(stateCodes).filter((stateCode) => stateCode === key)[0]],


### PR DESCRIPTION
Main fixes in this PR are:
- Added commas to all Title I subtitle tables - avg. base acres & avg. payment recipients. Also removed the extra `AVG.` in the `AVG. Recipient` header in several subtables
<img width="1190" height="418" alt="image" src="https://github.com/user-attachments/assets/b4a02c87-7ac6-4374-9e60-3b2a1676487b" />

- Added commas to Title II ACEP - No. of Contracts & Acres 
<img width="1307" height="342" alt="image" src="https://github.com/user-attachments/assets/f1b540cf-ff4f-4e19-b874-0bfff1eb635e" />

- Removed extra `$` sign for total benefit in all IRA dollar tables 
<img width="1024" height="420" alt="image" src="https://github.com/user-attachments/assets/21d559d5-b872-4254-a856-e5feb33feed5" />
