### PR TITLE
Release 1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [1.16.1] - 2026-03-26
 
 ### Changed
 - Removed the $ sign for the state-level and county-level insured acres maps in Crop Insurance[#452](https://github.com/policy-design-lab/pdl-frontend/issues/452)
@@ -434,6 +434,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Map data json [#12](https://github.com/policy-design-lab/pdl-frontend/issues/12)
 - Final landing page changes for initial milestone [#15](https://github.com/policy-design-lab/pdl-frontend/issues/15)
 
+[1.16.1]: https://github.com/policy-design-lab/pdl-frontend/compare/1.16.0...1.16.1
 [1.16.0]: https://github.com/policy-design-lab/pdl-frontend/compare/1.15.0...1.16.0
 [1.15.0]: https://github.com/policy-design-lab/pdl-frontend/compare/1.14.0...1.15.0
 [1.14.0]: https://github.com/policy-design-lab/pdl-frontend/compare/1.13.0...1.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+- Removed the $ sign for the state-level and county-level insured acres maps in Crop Insurance[#452](https://github.com/policy-design-lab/pdl-frontend/issues/452)
+
 ## [1.16.0] - 2026-03-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "policy-design-lab",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "policy-design-lab",
-      "version": "1.13.0",
+      "version": "1.16.0",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.10.4",
@@ -84,7 +84,7 @@
         "url-loader": "^4.1.1",
         "webpack": "^5.37.0",
         "webpack-bundle-analyzer": "^4.4.1",
-        "webpack-cli": "^4.7.0",
+        "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^3.11.2",
         "webpack-merge": "^5.7.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "policy-design-lab",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "the front end of policy design lab",
   "repository": "https://github.com/policy-design-lab/pdl-frontend",
   "main": "src/app.tsx",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "url-loader": "^4.1.1",
     "webpack": "^5.37.0",
     "webpack-bundle-analyzer": "^4.4.1",
-    "webpack-cli": "^4.7.0",
+    "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^3.11.2",
     "webpack-merge": "^5.7.3"
   }

--- a/src/components/cropinsurance/CropInsuranceCountyTable.tsx
+++ b/src/components/cropinsurance/CropInsuranceCountyTable.tsx
@@ -6,7 +6,7 @@ import SwapVertIcon from "@mui/icons-material/SwapVert";
 import { Grid, TableContainer, Typography, Box, FormControl, InputLabel, Select, MenuItem } from "@mui/material";
 import { compareWithNumber, compareWithAlphabetic, compareWithDollarSign } from "../shared/TableCompareFunctions";
 import "../../styles/table.css";
-import { formatCurrency } from "../shared/ConvertionFormats";
+import { formatCurrency, formatNumericValue } from "../shared/ConvertionFormats";
 import getCSVData from "../shared/getCSVData";
 
 interface CropInsuranceCountyTableProps {
@@ -71,10 +71,9 @@ function CropInsuranceCountyTable({
                         newRecord[attribute] = Number.isFinite(ratioValue)
                             ? ratioValue.toLocaleString(undefined, { maximumFractionDigits: 3 })
                             : "0";
-                    } else if (
-                        attribute === "averageInsuredAreaInAcres" ||
-                        attribute === "totalPoliciesEarningPremium"
-                    ) {
+                    } else if (attribute === "averageInsuredAreaInAcres") {
+                        newRecord[attribute] = formatNumericValue(Number(attributeData) || 0, 0);
+                    } else if (attribute === "totalPoliciesEarningPremium") {
                         newRecord[attribute] = formatCurrency(attributeData, 0);
                     } else {
                         newRecord[attribute] = formatCurrency(attributeData, 0);

--- a/src/components/cropinsurance/CropInsuranceTable.tsx
+++ b/src/components/cropinsurance/CropInsuranceTable.tsx
@@ -6,7 +6,7 @@ import SwapVertIcon from "@mui/icons-material/SwapVert";
 import { Grid, TableContainer, Typography, Box } from "@mui/material";
 import { compareWithNumber, compareWithAlphabetic, compareWithDollarSign } from "../shared/TableCompareFunctions";
 import "../../styles/table.css";
-import { formatCurrency } from "../shared/ConvertionFormats";
+import { formatCurrency, formatNumericValue } from "../shared/ConvertionFormats";
 import getCSVData from "../shared/getCSVData";
 
 function CropInsuranceProgramTable({
@@ -38,7 +38,9 @@ function CropInsuranceProgramTable({
                 newRecord[attr] = Number.isFinite(ratioValue)
                     ? ratioValue.toLocaleString(undefined, { maximumFractionDigits: 3 })
                     : "0";
-            } else if (attr === "averageInsuredAreaInAcres" || attr === "totalPoliciesEarningPremium") {
+            } else if (attr === "averageInsuredAreaInAcres") {
+                newRecord[attr] = formatNumericValue(Number(value) || 0, 0);
+            } else if (attr === "totalPoliciesEarningPremium") {
                 newRecord[attr] = formatCurrency(value, 0);
             } else {
                 newRecord[attr] = formatCurrency(value, 0);


### PR DESCRIPTION
## [1.16.1] - 2026-03-26

### Changed
- Removed the $ sign for the state-level and county-level insured acres maps in Crop Insurance[#452](https://github.com/policy-design-lab/pdl-frontend/issues/452)